### PR TITLE
Http param tests

### DIFF
--- a/gendoc/doctree/httpopts/contextualize.go
+++ b/gendoc/doctree/httpopts/contextualize.go
@@ -16,7 +16,6 @@ func Assemble(dt doctree.Doctree) {
 	for _, file := range md.Files {
 		for _, svc := range file.Services {
 			for _, meth := range svc.Methods {
-				//req := meth.RequestType
 				for _, pbind := range meth.HttpBindings {
 					err := contextualizeBinding(meth, pbind)
 					if err != nil {

--- a/gendoc/doctree/httpopts/contextualize_test.go
+++ b/gendoc/doctree/httpopts/contextualize_test.go
@@ -1,9 +1,9 @@
 package httpopts
 
 import (
-	//"strings"
-	dt "github.com/TuneLab/gob/gendoc/doctree"
 	"testing"
+
+	dt "github.com/TuneLab/gob/gendoc/doctree"
 )
 
 func TestGetPathParams(t *testing.T) {
@@ -19,5 +19,101 @@ func TestGetPathParams(t *testing.T) {
 	t.Log(params)
 	if len(params) != 2 {
 		t.Fatalf("Params (%v) is length '%v', expected length 2", params, len(params))
+	}
+}
+
+// Make sure that the location of fields in HTTP parameters matches up with the
+// locations specified within MethodHttpBinding
+func TestPostBodyParams(t *testing.T) {
+	typ := dt.FieldType{}
+	typ.SetName("TYPE_STRING")
+
+	msg := &dt.ProtoMessage{
+		Fields: []*dt.MessageField{
+			&dt.MessageField{
+				Number: 1,
+				Label:  "LABEL_OPTIONAL",
+				Type:   typ,
+			},
+			&dt.MessageField{
+				Number: 2,
+				Label:  "LABEL_OPTIONAL",
+				Type:   typ,
+			},
+			&dt.MessageField{
+				Number: 3,
+				Label:  "LABEL_OPTIONAL",
+				Type:   typ,
+			},
+		},
+	}
+	// In order to contextualize http bindings, there must be ProtoMessages
+	// with `Name` fields which match the ones specified within the
+	// BindingFields of the HttpBindings. However, since the `Name` field of
+	// pretty much all the types in the Doctree module are actually fields on
+	// embeded structs which aren't exported, we can't define the `Name` fields
+	// of MessageField types inline. For this reason, the MessageFields are
+	// defined above, but their names are set in the for loop below.
+	for count, field := range msg.Fields {
+		names := []string{"A", "B", "C"}
+		field.SetName(names[count])
+	}
+	md := &dt.MicroserviceDefinition{
+		Files: []*dt.ProtoFile{
+			&dt.ProtoFile{
+				Messages: []*dt.ProtoMessage{
+					msg,
+				},
+				Services: []*dt.ProtoService{
+					&dt.ProtoService{
+						Methods: []*dt.ServiceMethod{
+							&dt.ServiceMethod{
+								RequestType:  msg,
+								ResponseType: msg,
+								HttpBindings: []*dt.MethodHttpBinding{
+									&dt.MethodHttpBinding{
+										Fields: []*dt.BindingField{
+											&dt.BindingField{
+												Kind:  "post",
+												Value: `/{A}`,
+											},
+											&dt.BindingField{
+												Kind:  "body",
+												Value: `B`,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	Assemble(md)
+
+	params := md.Files[0].Services[0].Methods[0].HttpBindings[0].Params
+	if len(params) != 3 {
+		t.Fatalf("Params (%s) has length %v, expected length of 3.\n", params, len(params))
+	}
+
+	for _, param := range params {
+		switch param.Name {
+		case "A":
+			if param.Location != "path" {
+				t.Fatalf("Expected param '%s' to have location 'path', instead has location '%s'\n", param, param.Location)
+			}
+		case "B":
+			if param.Location != "body" {
+				t.Fatalf("Expected param '%s' to have location 'body', instead has location '%s'\n", param, param.Location)
+			}
+		case "C":
+			if param.Location != "query" {
+				t.Fatalf("Expected param '%s' to have location 'query', instead has location '%s'\n", param, param.Location)
+			}
+		}
+		t.Log(param)
 	}
 }

--- a/gendoc/svcparse/service_parser.go
+++ b/gendoc/svcparse/service_parser.go
@@ -19,12 +19,13 @@ package svcparse
 import (
 	"fmt"
 	"io"
+	"strconv"
 
 	"github.com/TuneLab/gob/gendoc/doctree"
 )
 
 func parseErr(expected string, line int, val string) error {
-	err := fmt.Errorf("Parser expected %v in line '%v', instead found '%v'", expected, line, val)
+	err := fmt.Errorf("parser expected %v in line '%v', instead found '%v'", expected, line, val)
 	return err
 }
 
@@ -34,7 +35,7 @@ func fastForwardTill(lex *SvcLexer, delim string) error {
 	for {
 		tk, val := lex.GetTokenIgnoreWhitespace()
 		if tk == EOF || tk == ILLEGAL {
-			return fmt.Errorf("In fastForwardTill found token of type '%v' and val '%v'", tk, val)
+			return fmt.Errorf("in fastForwardTill found token of type '%v' and val '%v'", tk, val)
 		} else if val == delim {
 			return nil
 		}
@@ -308,7 +309,11 @@ func ParseBindingFields(lex *SvcLexer) ([]*doctree.BindingField, error) {
 			return nil, parseErr("string literal", lex.GetLineNumber(), val)
 		}
 
-		field.Value = val
+		noqoute, err := strconv.Unquote(val)
+		if err != nil {
+			return nil, err
+		}
+		field.Value = noqoute
 
 		rv = append(rv, field)
 		field = &doctree.BindingField{}


### PR DESCRIPTION
This fixes the error with designating the location of http parameters in the `svcparse` module, as well as adds a test for designating http parameters in `httpopts`.
