### PR TITLE
Put back cleantest.sh to allow manual removal of generated test files

### DIFF
--- a/truss/Makefile
+++ b/truss/Makefile
@@ -13,11 +13,12 @@ clean:
 	rm -f $(GOPATH)/bin/truss
 	rm -f $(GOPATH)/bin/protoc-gen-truss-gokit
 	rm -f $(GOPATH)/bin/protoc-gen-truss-doc
-	rm -f $(GOPATH)/bin/truss-integration-runner
 
-# Run truss on all proto files in all dirs in ./tests/
 test:
-	go test -tags=integration
+	go test -tags=integration ./...
+
+testclean:
+	cd ./integration_tests && ./cleantest.sh
 
 
 

--- a/truss/integration_tests/cleantest.sh
+++ b/truss/integration_tests/cleantest.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Remove all the dir named `service/` in all dir's in test_service_definitions
+for dir in test_service_definitions/*
+do
+	# Ignore non-directories
+	if [ ! -d "$dir" ]; then
+		continue
+	fi
+	echo "$dir"
+	rm -rf "$dir"/service
+done


### PR DESCRIPTION
In using the integration tests I noticed I needed to still manually remove test files sometimes. I have added cleantest.sh back so that the Makefile can remove them.
