### PR TITLE
Add build flag for truss

### DIFF
--- a/truss/generator/generator.go
+++ b/truss/generator/generator.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 // GenerateMicroservice takes a golang importPath, a path to .proto definition files workingDirectory, and a slice of
-// definition files DefinitionFiles and outputs a ./service direcotry in workingDirectory with a generated and built golang microservice
+// definition files DefinitionFiles and outputs a ./service direcotry in workingDirectory with a generated microservice
 func GenerateMicroservice(importPath string, workingDirectory string, definitionFiles []string) {
 
 	done := make(chan bool)
@@ -41,6 +41,12 @@ func GenerateMicroservice(importPath string, workingDirectory string, definition
 	<-done
 	<-done
 	<-done
+}
+
+// BuildMicroservice builds a microservice using `$ go build` for a microservice generated with GenerateMicroservice
+func BuildMicroservice(importPath string) {
+
+	done := make(chan bool)
 
 	// Stage 5
 	go goBuild("server", importPath+"/service/DONOTEDIT/cmd/svc/...", done)

--- a/truss/main.go
+++ b/truss/main.go
@@ -21,6 +21,7 @@ func init() {
 
 // Stages are documented in README.md
 func main() {
+	buildMicroservice := flag.Bool("build", true, "Set -build=false to not build microservice")
 	flag.Parse()
 
 	if len(flag.Args()) == 0 {
@@ -72,4 +73,8 @@ func main() {
 	genImportPath := strings.TrimPrefix(workingDirectory, goPath+"/src/")
 
 	generator.GenerateMicroservice(genImportPath, workingDirectory, definitionFiles)
+
+	if *buildMicroservice {
+		generator.BuildMicroservice(genImportPath)
+	}
 }


### PR DESCRIPTION
The slowest part of truss is exec'ing $ go build for the generated
microservice. This commit adds a build flag to truss.

If truss is called as followed:
$ truss -build=false *.proto

The generated microservice will not be built.
This was added for using truss for tests that do not involve the built
microservice.
