### PR TITLE
Update truss to use NamedReadWriter Interface

### DIFF
--- a/gendoc/gendoc.go
+++ b/gendoc/gendoc.go
@@ -10,17 +10,16 @@ import (
 // GenerateDocs accepts a doctree that represents an ast of a group of
 // protofiles and returns a []truss.SimpleFile that represents a relative
 // filestructure of generated docs
-func GenerateDocs(dt doctree.Doctree) []truss.SimpleFile {
+func GenerateDocs(dt doctree.Doctree) []truss.NamedReadWriter {
 	response := dt.Markdown()
-	name := "service/docs/docs.md"
 
-	file := truss.SimpleFile{
-		Name:    &name,
-		Content: &response,
-	}
+	var file truss.SimpleFile
 
-	var files []truss.SimpleFile
-	files = append(files, file)
+	file.Path = "service/docs/docs.md"
+	file.Write([]byte(response))
+
+	var files []truss.NamedReadWriter
+	files = append(files, &file)
 
 	return files
 }

--- a/gengokit/astmodifier/astmodifier.go
+++ b/gengokit/astmodifier/astmodifier.go
@@ -7,6 +7,7 @@ import (
 	"go/parser"
 	"go/printer"
 	"go/token"
+	"io"
 	"os"
 
 	log "github.com/Sirupsen/logrus"
@@ -64,9 +65,9 @@ func NewFromFile(sourcePath string) *astModifier {
 }
 
 // New returns a new astModifier from a source file which modifies code intelligently
-func New(source *string) *astModifier {
+func New(source io.Reader) *astModifier {
 	fset := token.NewFileSet()
-	fileAst, err := parser.ParseFile(fset, "", *source, 0)
+	fileAst, err := parser.ParseFile(fset, "", source, 0)
 	if err != nil {
 		log.WithError(err).Fatal("server/service.go could not be parsed by go/parser into AST")
 	}

--- a/truss/truss/truss.go
+++ b/truss/truss/truss.go
@@ -2,10 +2,26 @@
 // the paths and contents of generated files
 package truss
 
-// SimpleFile stores a file name and that file's content
-// Name is a path relative to the directory containing the .proto files
-// Name should start with "service/" for all generated and read in files
+import (
+	"bytes"
+	"io"
+)
+
+// NamedReadWriter represents a file name and that file's content
+// Name() is a path relative to the directory containing the .proto files
+// Name() should start with "service/" for all generated and read in files
+// os.file fulfills the NamedReadWriter interface
+type NamedReadWriter interface {
+	io.ReadWriter
+	Name() string
+}
+
+// SimpleFile pointer implements the NamedReadWriter interface
 type SimpleFile struct {
-	Name    *string
-	Content *string
+	bytes.Buffer
+	Path string
+}
+
+func (s *SimpleFile) Name() string {
+	return s.Path
 }


### PR DESCRIPTION
The truss.NamedReadWriter interface has the methods Read, Write, and
Name. *os.File fulfills this interface. A slice of them can represent a
file structure. This allows files to be directly used as NameReadWriter's.

This also allows for a truss.NamedReadWriter to be passed to functions
that accept io.Reader or io.Writer.
