### PR TITLE
Fix server and client handler always being overwritten

### DIFF
--- a/gengokit/astmodifier/astmodifier.go
+++ b/gengokit/astmodifier/astmodifier.go
@@ -44,7 +44,7 @@ type interfaceRemover struct {
 // New returns a new astModifier from a source file which modifies code intelligently
 func NewFromFile(sourcePath string) *astModifier {
 	fset := token.NewFileSet()
-	fileAst, err := parser.ParseFile(fset, sourcePath, nil, 0)
+	fileAst, err := parser.ParseFile(fset, sourcePath, nil, parser.ParseComments)
 	if err != nil {
 		log.WithError(err).Fatal("server/service.go could not be parsed by go/parser into AST")
 	}
@@ -67,7 +67,7 @@ func NewFromFile(sourcePath string) *astModifier {
 // New returns a new astModifier from a source file which modifies code intelligently
 func New(source io.Reader) *astModifier {
 	fset := token.NewFileSet()
-	fileAst, err := parser.ParseFile(fset, "", source, 0)
+	fileAst, err := parser.ParseFile(fset, "", source, parser.ParseComments)
 	if err != nil {
 		log.WithError(err).Fatal("server/service.go could not be parsed by go/parser into AST")
 	}

--- a/truss/main.go
+++ b/truss/main.go
@@ -155,7 +155,7 @@ func exitIfError(err error) {
 // readPreviousGeneration accepts the path to the directory where the inputed .proto files are stored, protoDir,
 // it returns a []truss.NamedReadWriter for all files in the service/ dir in protoDir
 func readPreviousGeneration(protoDir, packageName string) ([]truss.NamedReadWriter, error) {
-	dir := protoDir + "/" + packageName + "-microsvc"
+	dir := protoDir + "/" + packageName + "-service"
 	if fileExists(dir) != true {
 		return nil, nil
 	}
@@ -167,7 +167,7 @@ func readPreviousGeneration(protoDir, packageName string) ([]truss.NamedReadWrit
 	}
 	err := filepath.Walk(dir, sfs.makeSimpleFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not fully walk directory %v/service", protoDir)
+		return nil, errors.Wrapf(err, "could not fully walk directory %v", protoDir)
 	}
 
 	return sfs.files, nil


### PR DESCRIPTION
A bug introduced when truss's output was restructured was that the
server and client handlers were not being parsed. This was a
combination of truss not reading in files properly and gengokit not
searching the read in files properly. These both have been fixed.

Also added parsing of comments of server and client handler which was
an early oversight
