### PR TITLE
 Update server handlers to use pointers to pb structs

### DIFF
--- a/gengokit/template/NAME-service/generated/endpoints.gotemplate
+++ b/gengokit/template/NAME-service/generated/endpoints.gotemplate
@@ -41,12 +41,12 @@ type Endpoints struct {
 
 // Endpoints
 {{range $i := .Service.Methods}}
-func (e Endpoints) {{$i.GetName}}(ctx context.Context, in pb.{{GoName $i.RequestType.GetName}}) (pb.{{GoName $i.ResponseType.GetName}}, error) {
+func (e Endpoints) {{$i.GetName}}(ctx context.Context, in *pb.{{GoName $i.RequestType.GetName}}) (*pb.{{GoName $i.ResponseType.GetName}}, error) {
 	response, err := e.{{$i.GetName}}Endpoint(ctx, in)
 	if err != nil {
-		return pb.{{GoName $i.ResponseType.GetName}}{}, err
+		return nil, err
 	}
-	return *response.(*pb.{{GoName $i.ResponseType.GetName}}), nil
+	return response.(*pb.{{GoName $i.ResponseType.GetName}}), nil
 }
 {{end}}
 
@@ -55,11 +55,11 @@ func (e Endpoints) {{$i.GetName}}(ctx context.Context, in pb.{{GoName $i.Request
 func Make{{$i.GetName}}Endpoint(s handler.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 		req := request.(*pb.{{GoName $i.RequestType.GetName}})
-		v, err := s.{{$i.GetName}}(ctx, *req)
+		v, err := s.{{$i.GetName}}(ctx, req)
 		if err != nil {
-			return nil, err // special case; see comment on ErrIntOverflow
+			return nil, err
 		}
-		return &v, nil
+		return v, nil
 	}
 }
 {{end}}

--- a/gengokit/template/NAME-service/generated/transport_grpc.gotemplate
+++ b/gengokit/template/NAME-service/generated/transport_grpc.gotemplate
@@ -90,8 +90,8 @@ func EncodeGRPC{{$i.GetName}}Response(_ context.Context, response interface{}) (
 // EncodeGRPC{{$i.GetName}}Request is a transport/grpc.EncodeRequestFunc that converts a
 // user-domain {{ToLower $i.GetName}} request to a gRPC {{ToLower $i.GetName}} request. Primarily useful in a client.
 func EncodeGRPC{{$i.GetName}}Request(_ context.Context, request interface{}) (interface{}, error) {
-	req := request.(pb.{{GoName $i.RequestType.GetName}})
-	return &req, nil
+	req := request.(*pb.{{GoName $i.RequestType.GetName}})
+	return req, nil
 }
 {{end}}
 

--- a/gengokit/template/NAME-service/handlers/client/client_handler.gotemplate
+++ b/gengokit/template/NAME-service/handlers/client/client_handler.gotemplate
@@ -8,7 +8,7 @@ import (
 
 {{range $i := $templateExecutor.Service.Methods}}
 // {{$i.GetName}} implements Service.
-func {{$i.GetName}}({{with index $templateExecutor.ClientArgs.MethArgs $i.GetName}}{{GoName .FunctionArgs}}{{end}}) (pb.{{GoName $i.RequestType.GetName}}, error){
+func {{$i.GetName}}({{with index $templateExecutor.ClientArgs.MethArgs $i.GetName}}{{GoName .FunctionArgs}}{{end}}) (*pb.{{GoName $i.RequestType.GetName}}, error){
 {{- with $meth := index $templateExecutor.ClientArgs.MethArgs $i.GetName -}}
 	{{- range $param := $meth.Args -}}
 		{{- if not $param.IsBaseType -}}
@@ -25,7 +25,7 @@ func {{$i.GetName}}({{with index $templateExecutor.ClientArgs.MethArgs $i.GetNam
 	{{end -}}
 {{- end -}}
 	}
-	return request, nil
+	return &request, nil
 }
 {{end}}
 

--- a/gengokit/template/NAME-service/handlers/server/server_handler.gotemplate
+++ b/gengokit/template/NAME-service/handlers/server/server_handler.gotemplate
@@ -29,13 +29,15 @@ type {{.PackageName}}Service struct{}
 
 {{range $i := $Executor.Service.Methods}}
 // {{$i.GetName}} implements Service.
-func (s {{$PackageName}}Service) {{$i.GetName}}(ctx context.Context, in pb.{{GoName $i.RequestType.GetName}}) (pb.{{GoName $i.ResponseType.GetName}}, error){
+func (s {{$PackageName}}Service) {{$i.GetName}}(ctx context.Context, in *pb.{{GoName $i.RequestType.GetName}}) (*pb.{{GoName $i.ResponseType.GetName}}, error){
 	_ = ctx
 	_ = in
 	response := pb.{{GoName $i.ResponseType.GetName}}{
-		//
+		{{range $j := $i.ResponseType.Fields -}}
+		// {{GoName $j.GetName }}: 
+		{{end -}}
 	}
-	return response, nil
+	return &response, nil
 }
 {{end}}
 {{- end}}
@@ -43,6 +45,6 @@ func (s {{$PackageName}}Service) {{$i.GetName}}(ctx context.Context, in pb.{{GoN
 
 type Service interface {
 {{range $i := .Service.Methods}}
-	{{$i.GetName}}(ctx context.Context, in pb.{{GoName $i.RequestType.GetName}}) (pb.{{GoName $i.ResponseType.GetName}}, error)
+	{{$i.GetName}}(ctx context.Context, in *pb.{{GoName $i.RequestType.GetName}}) (*pb.{{GoName $i.ResponseType.GetName}}, error)
 {{- end}}
 }

--- a/gengokit/template/NAME-service/partial_template/client_handler.methods
+++ b/gengokit/template/NAME-service/partial_template/client_handler.methods
@@ -2,7 +2,7 @@
 
 {{range $i := $templateExecutor.Service.Methods}}
 // {{$i.GetName}} implements Service.
-func {{$i.GetName}}({{with index $templateExecutor.ClientArgs.MethArgs $i.GetName}}{{GoName .FunctionArgs}}{{end}}) (pb.{{GoName $i.RequestType.GetName}}, error){
+func {{$i.GetName}}({{with index $templateExecutor.ClientArgs.MethArgs $i.GetName}}{{GoName .FunctionArgs}}{{end}}) (*pb.{{GoName $i.RequestType.GetName}}, error){
 {{- with $meth := index $templateExecutor.ClientArgs.MethArgs $i.GetName -}}
 	{{- range $param := $meth.Args -}}
 		{{- if not $param.IsBaseType -}}
@@ -19,7 +19,7 @@ func {{$i.GetName}}({{with index $templateExecutor.ClientArgs.MethArgs $i.GetNam
 	{{end -}}
 {{- end -}}
 	}
-	return request, nil
+	return &request, nil
 }
 {{end}}
 {{- end}}

--- a/gengokit/template/NAME-service/partial_template/service.interface
+++ b/gengokit/template/NAME-service/partial_template/service.interface
@@ -1,5 +1,5 @@
 type Service interface {
 {{range $i := .Service.Methods}}
-	{{$i.GetName}}(ctx context.Context, in pb.{{GoName $i.RequestType.GetName}}) (pb.{{GoName $i.ResponseType.GetName}}, error)
+	{{$i.GetName}}(ctx context.Context, in *pb.{{GoName $i.RequestType.GetName}}) (*pb.{{GoName $i.ResponseType.GetName}}, error)
 {{- end}}
 }

--- a/gengokit/template/NAME-service/partial_template/service.methods
+++ b/gengokit/template/NAME-service/partial_template/service.methods
@@ -3,13 +3,15 @@
 
 {{range $i := $templateExecutor.Service.Methods}}
 // {{.GetName}} implements Service.
-func (s {{$PackageName}}Service) {{.GetName}}(ctx context.Context, in pb.{{GoName .RequestType.GetName}}) (pb.{{GoName .ResponseType.GetName}}, error){
+func (s {{$PackageName}}Service) {{.GetName}}(ctx context.Context, in *pb.{{GoName .RequestType.GetName}}) (*pb.{{GoName .ResponseType.GetName}}, error){
 	_ = ctx
 	_ = in
 	response := pb.{{GoName .ResponseType.GetName}}{
-		//
+		{{range $j := $i.ResponseType.Fields -}}
+		// {{GoName $j.GetName }}: 
+		{{end -}}
 	}
-	return response, nil
+	return &response, nil
 }
 {{end}}
 


### PR DESCRIPTION
grpc golang structures were being dereferenced in endpoints.go then
passed to the server handlers, then the return value was being
referenced in endpoints.go and returned up the stack. Now the pointer
is directly passed to the server handler and the server handler returns
a pointer to the response type.

Also added listing the response type message fields as comments to the server
handler template. This allows for quickly creating a response struct by
uncommenting the fields you want to populate
