### PR TITLE
Add deftree.NewFromString, Refactor gengokit. Add gengokit_test.go

### DIFF
--- a/deftree/build_deftree.go
+++ b/deftree/build_deftree.go
@@ -82,11 +82,14 @@ func NewFromString(def string) (Deftree, error) {
 	const defFileName = "definition.proto"
 
 	protoDir, err := ioutil.TempDir("", "truss-deftree-")
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create temp directory to store proto definition")
+	}
 	defer os.RemoveAll(protoDir)
 
-	err = ioutil.WriteFile(protoDir+"/"+defFileName, []byte(def), 0666)
+	err = ioutil.WriteFile(filepath.Join(protoDir, defFileName), []byte(def), 0666)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not write proto definition to filesystem")
+		return nil, errors.Wrap(err, "could not write proto definition to file")
 	}
 
 	err = protostage.Stage(protoDir)
@@ -221,7 +224,7 @@ func findMessage(md *MicroserviceDefinition, newFile *ProtoFile, path string) (*
 			}
 		}
 	}
-	return nil, fmt.Errorf("couldn't find message.")
+	return nil, fmt.Errorf("couldn't find message")
 }
 
 // NewService creates a new *ProtoService from a

--- a/deftree/build_deftree.go
+++ b/deftree/build_deftree.go
@@ -6,17 +6,19 @@ package deftree
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
-	"github.com/TuneLab/go-truss/deftree/svcparse"
-
 	log "github.com/Sirupsen/logrus"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"github.com/pkg/errors"
+
+	"github.com/TuneLab/go-truss/deftree/svcparse"
+	"github.com/TuneLab/go-truss/truss/protostage"
 )
 
 func init() {
@@ -29,47 +31,6 @@ func init() {
 
 	// Only log the warning severity or above.
 	log.SetLevel(log.InfoLevel)
-}
-
-// Finds the package name of the proto files named on the command line
-func findDeftreePackage(req *plugin.CodeGeneratorRequest) string {
-	for _, cmdFile := range req.GetFileToGenerate() {
-		for _, protoFile := range req.GetProtoFile() {
-			if protoFile.GetName() == cmdFile {
-				return protoFile.GetPackage()
-			}
-		}
-	}
-	return ""
-}
-
-// Finds a message given a fully qualified name to that message. The provided
-// path may be either a fully qualfied name of a message, or just the bare name
-// for a message.
-func findMessage(md *MicroserviceDefinition, newFile *ProtoFile, path string) (*ProtoMessage, error) {
-	if path[0] == '.' {
-		parts := strings.Split(path, ".")
-		for _, file := range md.Files {
-			for _, msg := range file.Messages {
-				if parts[2] == msg.GetName() {
-					return msg, nil
-				}
-			}
-		}
-		for _, msg := range newFile.Messages {
-			if parts[2] == msg.GetName() {
-				return msg, nil
-			}
-		}
-	} else {
-		for _, msg := range newFile.Messages {
-			if path == msg.GetName() {
-				return msg, nil
-			}
-		}
-	}
-	return nil, fmt.Errorf("couldn't find message.")
-
 }
 
 // New accepts a Protobuf plugin.CodeGeneratorRequest and the contents of the
@@ -115,6 +76,47 @@ func New(req *plugin.CodeGeneratorRequest, serviceFile io.Reader) (Deftree, erro
 	}
 
 	return &dt, nil
+}
+
+func NewFromString(def string) (Deftree, error) {
+	const defFileName = "definition.proto"
+
+	protoDir, err := ioutil.TempDir("", "truss-deftree-")
+	defer os.RemoveAll(protoDir)
+
+	err = ioutil.WriteFile(protoDir+"/"+defFileName, []byte(def), 0666)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not write proto definition to filesystem")
+	}
+
+	err = protostage.Stage(protoDir)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to prepare filesystem for generating deftree")
+	}
+
+	req, svcFile, err := protostage.Compose([]string{defFileName}, protoDir)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get CodeGeneratorRequest for generating deftree")
+	}
+
+	deftree, err := New(req, svcFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "can not create new deftree")
+	}
+
+	return deftree, nil
+}
+
+// Finds the package name of the proto files named on the command line
+func findDeftreePackage(req *plugin.CodeGeneratorRequest) string {
+	for _, cmdFile := range req.GetFileToGenerate() {
+		for _, protoFile := range req.GetProtoFile() {
+			if protoFile.GetName() == cmdFile {
+				return protoFile.GetPackage()
+			}
+		}
+	}
+	return ""
 }
 
 // Build a new deftree.File struct
@@ -192,6 +194,34 @@ func NewMessage(msg *descriptor.DescriptorProto) (*ProtoMessage, error) {
 		newMsg.Fields = append(newMsg.Fields, &newField)
 	}
 	return &newMsg, nil
+}
+
+// Finds a message given a fully qualified name to that message. The provided
+// path may be either a fully qualfied name of a message, or just the bare name
+// for a message.
+func findMessage(md *MicroserviceDefinition, newFile *ProtoFile, path string) (*ProtoMessage, error) {
+	if path[0] == '.' {
+		parts := strings.Split(path, ".")
+		for _, file := range md.Files {
+			for _, msg := range file.Messages {
+				if parts[2] == msg.GetName() {
+					return msg, nil
+				}
+			}
+		}
+		for _, msg := range newFile.Messages {
+			if parts[2] == msg.GetName() {
+				return msg, nil
+			}
+		}
+	} else {
+		for _, msg := range newFile.Messages {
+			if path == msg.GetName() {
+				return msg, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("couldn't find message.")
 }
 
 // NewService creates a new *ProtoService from a

--- a/deftree/build_deftree_test.go
+++ b/deftree/build_deftree_test.go
@@ -14,6 +14,47 @@ import (
 	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
 
+func TestNewFromString(t *testing.T) {
+	const def = `
+		syntax = "proto3";
+
+		// General package
+		package general;
+
+		import "google/api/annotations.proto";
+
+		// RequestMessage is so foo
+		message RequestMessage {
+		  string input = 1;
+		}
+
+		// ResponseMessage is so bar
+		message ResponseMessage {
+		  string output = 1;
+		}
+
+		// ProtoService is a service
+		service ProtoService {
+		  // ProtoMethod is simple. Like a gopher.
+		  rpc ProtoMethod (RequestMessage) returns (ResponseMessage) {
+			// No {} in path and no body, everything is in the query
+			option (google.api.http) = {
+			  get: "/route"
+			};
+		  }
+		}
+	`
+
+	deftree, err := NewFromString(def)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if got, want := deftree.GetName(), "general"; got != want {
+		t.Errorf("\n`%v` was deftree package name\n`%v` was wanted", got, want)
+	}
+}
+
 func TestNewFile(t *testing.T) {
 	src := `
 		name: "path/to/example.proto",

--- a/deftree/build_deftree_test.go
+++ b/deftree/build_deftree_test.go
@@ -51,7 +51,7 @@ func TestNewFromString(t *testing.T) {
 	}
 
 	if got, want := deftree.GetName(), "general"; got != want {
-		t.Errorf("\n`%v` was deftree package name\n`%v` was wanted", got, want)
+		t.Errorf("`%v` was deftree package name \n`%v` was wanted", got, want)
 	}
 }
 

--- a/gengokit/gengokit.go
+++ b/gengokit/gengokit.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"go/format"
 	"io"
-	//"io/ioutil"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,10 +31,6 @@ func init() {
 	})
 }
 
-type generator struct {
-	templateExec templateExecutor
-}
-
 // templateExecutor is passed to templates as the executing struct its fields
 // and methods are used to modify the template
 type templateExecutor struct {
@@ -47,28 +43,64 @@ type templateExecutor struct {
 	ClientArgs *clientarggen.ClientServiceArgs
 	// A helper struct for generating http transport functionality.
 	HTTPHelper *httptransport.Helper
+	funcMap    template.FuncMap
 }
 
-// GenerateGokit accepts a deftree representing the ast of a group of .proto
-// files, a []truss.NamedReadWriter representing files generated previously, and
-// a goImportPath for templating go code imports
-// GenerateGoCode returns the a []truss.NamedReadWriter representing a generated
-// gokit microservice file structure
-func GenerateGokit(dt deftree.Deftree, previousFiles []truss.NamedReadWriter, goImportPath string) ([]truss.NamedReadWriter, error) {
+// newTemplateExecutor accepts a deftree and a goImportPath to construct a
+// templateExecutor for templating a service
+func newTemplateExecutor(dt deftree.Deftree, goImportPath string) (*templateExecutor, error) {
 	service, err := getProtoService(dt)
 	if err != nil {
-		return nil, errors.Wrap(err, "no service found aborting generating gokit microservice")
+		return nil, errors.Wrap(err, "no service found aborting generating gokit service")
 	}
 
 	importPath := goImportPath + "/" + dt.GetName() + "-service"
-	g := newGenerator(service, importPath, dt.GetName())
-	files, err := g.GenerateResponseFiles(previousFiles, dt.GetName())
+	funcMap := template.FuncMap{
+		"ToLower":    strings.ToLower,
+		"Title":      strings.Title,
+		"GoName":     generatego.CamelCase,
+		"TrimPrefix": strings.TrimPrefix,
+	}
+	return &templateExecutor{
+		ImportPath:  importPath,
+		PackageName: dt.GetName(),
+		Service:     service,
+		ClientArgs:  clientarggen.New(service),
+		HTTPHelper:  httptransport.NewHelper(service),
+		funcMap:     funcMap,
+	}, nil
+}
 
+// GenerateGokit accepts a deftree representing the ast of a group of .proto
+// files, a []truss.NamedReadWriter representing files generated previously
+// (which may be nil for no previously generated files), and a goImportPath for
+// templating go code imports. GenerateGokit returns the a
+// []truss.NamedReadWriter representing a generated gokit service file
+// structure
+func GenerateGokit(dt deftree.Deftree, previousFiles []truss.NamedReadWriter, goImportPath string) ([]truss.NamedReadWriter, error) {
+
+	te, err := newTemplateExecutor(dt, goImportPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not generate gokit microservice")
+		return nil, errors.Wrap(err, "could not create template executor")
 	}
 
-	return files, nil
+	fpm := filesToFilepathMap(previousFiles)
+
+	var codeGenFiles []truss.NamedReadWriter
+
+	for _, templFP := range templateFileAssets.AssetNames() {
+		file, err := generateResponseFile(templFP, te, fpm)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not render template")
+		}
+		if file == nil {
+			continue
+		}
+
+		codeGenFiles = append(codeGenFiles, file)
+	}
+
+	return codeGenFiles, nil
 }
 
 // getProtoService finds returns the service within a deftree.Deftree
@@ -86,37 +118,103 @@ func getProtoService(dt deftree.Deftree) (*deftree.ProtoService, error) {
 	if service == nil {
 		return nil, errors.New("no service found")
 	}
-
 	return service, nil
 }
 
-// newGenerator returns a new generator which generates a gokit microservice
-func newGenerator(service *deftree.ProtoService, importPath string, pkgName string) *generator {
-	return &generator{
-		templateExec: templateExecutor{
-			ImportPath:  importPath,
-			PackageName: pkgName,
-			Service:     service,
-			ClientArgs:  clientarggen.New(service),
-			HTTPHelper:  httptransport.NewHelper(service),
-		},
+// generateResponseFile contains logic to choose how to render a template file
+// based on path and if that file was generated previously. It accepts a
+// template path to render, a templateExecutor to apply to the template, and a
+// map of paths to files for the previous generation. It returns a
+// truss.NamedReadWriter representing the generated file
+func generateResponseFile(templFP string, te *templateExecutor, prevGenMap map[string]io.Reader) (truss.NamedReadWriter, error) {
+	// Only .gotemplate files are rendered
+	if filepath.Ext(templFP) != ".gotemplate" {
+		log.WithField("Template file", templFP).Debug("Skipping rendering non-buildable partial template")
+		return nil, nil
 	}
-}
 
-// getFileContentByName searches though a []truss.NamedReadWriter and returns the
-// contents of the file with the name n
-func getFileByName(n string, files []truss.NamedReadWriter) io.Reader {
-	for _, f := range files {
-		if f.Name() == n {
-			return f
+	var genCode io.Reader
+	var err error
+
+	// Get the actual path to the file rather than the template file path
+	actualFP := templatePathToActual(templFP, te.PackageName)
+
+	// Map of template paths to template rendering functions
+	renderFuncs := map[string]func(io.Reader, *templateExecutor) (io.Reader, error){
+		"NAME-service/handlers/server/server_handler.gotemplate": updateServerMethods,
+		"NAME-service/handlers/client/client_handler.gotemplate": updateClientMethods,
+	}
+
+	// If we are rendering a template with a renderFunc and the file existed
+	// previously then use that function
+	if renderFuncs[templFP] != nil {
+		file := prevGenMap[actualFP]
+		if file != nil {
+			genCode, err = renderFuncs[templFP](file, te)
 		}
 	}
-	return nil
+
+	if err != nil {
+		return nil, errors.Wrap(err, "could not render template")
+	}
+
+	// if no code has been generated just apply the template
+	if genCode == nil {
+		genCode, err = applyTemplateFromPath(templFP, te)
+	}
+
+	if err != nil {
+		return nil, errors.Wrap(err, "could not render template")
+	}
+
+	// Turn code buffer into string and format it
+	codeBytes, err := ioutil.ReadAll(genCode)
+	if err != nil {
+		return nil, err
+	}
+
+	// ignore error as we want to write the code either way to inspect after
+	// writing to disk
+	formattedCode, _ := formatCode(codeBytes)
+
+	var resp truss.SimpleFile
+
+	// Set the path to the file and write the code to the file
+	resp.Path = actualFP
+	resp.Write(formattedCode)
+
+	return &resp, nil
 }
 
-// updateServerMethods will update the functions within an existing server_handler.go
-// file so it contains all the functions within svcFuncs
-func (g *generator) updateServerMethods(svcHandler io.Reader, svcFuncs []string) (outCode *bytes.Buffer, err error) {
+// templatePathToActual accepts a templateFilePath and the packageName of the
+// service and returns what the relative file path of what should be written to
+// disk
+func templatePathToActual(templFilePath, packageName string) string {
+	// Switch "NAME" in path with packageName.
+	//i.e. for packageName = addsvc; /NAME-service/NAME-server -> /addsvc-service/addsvc-server
+	actual := strings.Replace(templFilePath, "NAME", packageName, -1)
+
+	actual = strings.TrimSuffix(actual, "template")
+
+	return actual
+}
+
+// filesTofilepathMap accepts a slice of truss.NamedReadWriters and returns a map of filepaths
+// as strings to files as io.Reader
+func filesToFilepathMap(previousFiles []truss.NamedReadWriter) (pathToFile map[string]io.Reader) {
+	pathToFile = make(map[string]io.Reader)
+	for _, f := range previousFiles {
+		pathToFile[f.Name()] = f
+	}
+	return pathToFile
+}
+
+// updateServerMethods accepts NAME-service/handlers/server/server_handlers.go
+// as an io.Reader and modifies it to contains only functions returned by
+// serviceFunctionNames.
+func updateServerMethods(svcHandler io.Reader, te *templateExecutor) (outCode io.Reader, err error) {
+	svcFuncs := serviceFunctionsNames(te.Service.Methods)
+
 	const svcMethodsTemplPath = "NAME-service/partial_template/service.methods"
 	const svcInterfaceTemplPath = "NAME-service/partial_template/service.interface"
 
@@ -125,31 +223,39 @@ func (g *generator) updateServerMethods(svcHandler io.Reader, svcFuncs []string)
 	astMod.RemoveFunctionsExecpt(svcFuncs)
 	astMod.RemoveInterface("Service")
 
-	// Index the handler functions, apply handler template for all function in service definition that are not defined in handler
+	// Index the handler functions, apply handler template for all function in
+	// service definition that are not defined in handler
 	currentFuncs := astMod.IndexFunctions()
 	code := astMod.Buffer()
 
-	err = g.applyTemplateForMissingMeths(svcMethodsTemplPath, currentFuncs, code)
+	trimmedTe, err := trimTemplateExecutorServiceFuncs(*te, currentFuncs)
+
+	out, err := applyTemplateFromPath(svcMethodsTemplPath, trimmedTe)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to apply service methods template")
 	}
 
+	code.ReadFrom(out)
+
 	// Insert updated Service interface
-	outBuf, err := applyTemplateFromPath(svcInterfaceTemplPath, g.templateExec)
+	out, err = applyTemplateFromPath(svcInterfaceTemplPath, te)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to apply service interface template")
 	}
 
-	code.Write(outBuf.Bytes())
+	code.ReadFrom(out)
 
 	return code, nil
 }
 
-// updateClientMethods will update the functions within an existing
-// client_handler.go file so that it contains exactly the fucntions passed in
-// svcFuncs, no more, no less.
-func (g *generator) updateClientMethods(clientHandler io.Reader, svcFuncs []string) (outCode *bytes.Buffer, err error) {
+// updateClientMethods accepts NAME-service/handlers/client/client_handler.go
+// as an io.Reader and modifies it to contains only functions returned by
+// serviceFunctionNames.
+func updateClientMethods(clientHandler io.Reader, te *templateExecutor) (outCode io.Reader, err error) {
+	svcFuncs := serviceFunctionsNames(te.Service.Methods)
+
 	const clientMethodsTemplPath = "NAME-service/partial_template/client_handler.methods"
+
 	astMod := astmodifier.New(clientHandler)
 
 	// Remove functions no longer in definition
@@ -160,102 +266,42 @@ func (g *generator) updateClientMethods(clientHandler io.Reader, svcFuncs []stri
 	currentFuncs := astMod.IndexFunctions()
 	code := astMod.Buffer()
 
-	err = g.applyTemplateForMissingMeths(clientMethodsTemplPath, currentFuncs, code)
+	// Get a templateExecutor that is identical but with only functions in the
+	// definition file and not in the previously generated file
+	trimmedTe, err := trimTemplateExecutorServiceFuncs(*te, currentFuncs)
 
+	out, err := applyTemplateFromPath(clientMethodsTemplPath, trimmedTe)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to apply client methods template")
 	}
 
+	code.ReadFrom(out)
+
 	return code, nil
 }
 
-// GenerateResponseFiles applies all template files for the generated
-// microservice and returns a slice containing each templated file as a
-// truss.NamedReadWriter.
-func (g *generator) GenerateResponseFiles(previousFiles []truss.NamedReadWriter, packageName string) ([]truss.NamedReadWriter, error) {
-	// Paths to handler files that may be modified programmatically
-	serverHandlerFilePath := "-service/handlers/server/server_handler.go"
-	clientHandlerFilePath := "-service/handlers/client/client_handler.go"
-
-	var codeGenFiles []truss.NamedReadWriter
-
-	// serviceFunctions is used later as the master list of all service methods
-	// which should exist within the handler files
-	var serviceFunctions []string
-	for _, meth := range g.templateExec.Service.Methods {
-		serviceFunctions = append(serviceFunctions, meth.GetName())
+// serviceFunctionNames returns a slice of function names which are in the
+// definition files plus the function "NewService". Used for inserting and
+// removing functions from previously generated handler files
+func serviceFunctionsNames(meths []*deftree.ServiceMethod) []string {
+	var svcFuncs []string
+	for _, meth := range meths {
+		svcFuncs = append(svcFuncs, meth.GetName())
 	}
-	serviceFunctions = append(serviceFunctions, "NewBasicService")
+	svcFuncs = append(svcFuncs, "NewService")
 
-	serverHandlerFile := getFileByName(packageName+serverHandlerFilePath, previousFiles)
-	clientHandlerFile := getFileByName(packageName+clientHandlerFilePath, previousFiles)
-
-	for _, templateFilePath := range templateFileAssets.AssetNames() {
-		if filepath.Ext(templateFilePath) != ".gotemplate" {
-			log.WithField("Template file", templateFilePath).Debug("Skipping rendering non-buildable partial template")
-			continue
-		}
-
-		var generatedFilePath string
-		var generatedCode *bytes.Buffer
-		var err error
-
-		if templateFilePath == "NAME"+serverHandlerFilePath+"template" && serverHandlerFile != nil {
-			// If there's an existing service file, update its contents
-
-			generatedCode, err = g.updateServerMethods(serverHandlerFile, serviceFunctions)
-
-			if err != nil {
-				return nil, errors.Wrap(err, "could not modifiy service handler file")
-			}
-
-		} else if templateFilePath == "NAME"+clientHandlerFilePath+"template" && clientHandlerFile != nil {
-			// If there's an existing client_handler file, update its contents
-
-			generatedCode, err = g.updateClientMethods(clientHandlerFile, serviceFunctions)
-
-			if err != nil {
-				return nil, errors.Wrap(err, "could not modifiy client handler file")
-			}
-
-		} else {
-
-			generatedCode, err = applyTemplateFromPath(templateFilePath, g.templateExec)
-			if err != nil {
-				return nil, errors.Wrap(err, "could not render template")
-			}
-		}
-
-		generatedFilePath = templateFilePath
-		// Change file path from .gotemplate to .go
-		generatedFilePath = strings.TrimSuffix(generatedFilePath, "template")
-
-		// Turn code buffer into string and format it
-		formattedCode := formatCode(generatedCode.Bytes())
-
-		var resp truss.SimpleFile
-
-		// Switch "NAME" in path with packageName.
-		//i.e. for packageName = addsvc; /NAME-service/NAME-server -> /addsvc-service/addsvc-server
-		resp.Path = strings.Replace(generatedFilePath, "NAME", packageName, -1)
-
-		resp.Write(formattedCode)
-
-		codeGenFiles = append(codeGenFiles, &resp)
-	}
-
-	return codeGenFiles, nil
+	return svcFuncs
 }
 
-// applyTemplateForMissingMeths accepts a funcIndex which represents functions
-// already present in a gofile, applyTemplateForMissingMeths compares this map
-// to the functions defined in the service and renders the template with the
-// path of templPath, and appends this to passed code
-func (g *generator) applyTemplateForMissingMeths(templPath string, funcIndex map[string]bool, code *bytes.Buffer) error {
+// trimTemplateExecutorServiceFuncs removes functions in funcsInFile from the
+// passed templateExecutor and returns a pointer to that templateExecutor
+func trimTemplateExecutorServiceFuncs(te templateExecutor, funcsInFile map[string]bool) (*templateExecutor, error) {
 	var methodsToTemplate []*deftree.ServiceMethod
-	for _, meth := range g.templateExec.Service.Methods {
+
+	for _, meth := range te.Service.Methods {
 		methName := meth.GetName()
-		if funcIndex[methName] == false {
+
+		if funcsInFile[methName] == false {
 			methodsToTemplate = append(methodsToTemplate, meth)
 			log.WithField("Method", methName).Info("Rendering template for method")
 		} else {
@@ -263,31 +309,19 @@ func (g *generator) applyTemplateForMissingMeths(templPath string, funcIndex map
 		}
 	}
 
-	// Create temporary templateExec with only the methods we want to append
-	// We must also dereference the templateExec's Service and change our newly created
-	// Service's pointer to it's messages to be methodsToTemplate
-	templateExecWithOnlyMissingMethods := g.templateExec
-	tempService := *g.templateExec.Service
+	// templateExec's Service is dereference and that new Service's
+	// pointer to it's messages is changed to be methodsToTemplate
+	tempService := *te.Service
 	tempService.Methods = methodsToTemplate
-	templateExecWithOnlyMissingMethods.Service = &tempService
 
-	// Apply the template and write it to code
-	templateOut, err := applyTemplateFromPath(templPath, templateExecWithOnlyMissingMethods)
-	if err != nil {
-		return errors.Wrapf(err, "could not apply template for missing methods: %v", templPath)
-	}
+	te.Service = &tempService
 
-	_, err = code.Write(templateOut.Bytes())
-	if err != nil {
-		return errors.Wrap(err, "could not append rendered template to code")
-	}
-
-	return nil
+	return &te, nil
 }
 
-// applyTemplateFromPath accepts a path to a template and an interface to execute on that template
-// returns a *bytes.Buffer containing the results of that execution
-func applyTemplateFromPath(templFilePath string, executor interface{}) (*bytes.Buffer, error) {
+// applyTemplateFromPath accepts a path to a template and a templateExecutor and calls
+// applyTemplate with the template at that template path and returns the result
+func applyTemplateFromPath(templFilePath string, executor *templateExecutor) (io.Reader, error) {
 
 	templBytes, err := templateFileAssets.Asset(templFilePath)
 	if err != nil {
@@ -298,20 +332,13 @@ func applyTemplateFromPath(templFilePath string, executor interface{}) (*bytes.B
 }
 
 // applyTemplate accepts a []byte, and a string representing the content and
-// name of a template and an interface to execute on that template returns a
-// *bytes.Buffer containing the results of that execution
-func applyTemplate(templBytes []byte, templName string, executor interface{}) (*bytes.Buffer, error) {
+// name of a template and a templateExecutor to execute on that template. Returns a
+// io.Reader containing the results of that execution
+func applyTemplate(templBytes []byte, templName string, executor *templateExecutor) (io.Reader, error) {
 
 	templateString := string(templBytes)
 
-	funcMap := template.FuncMap{
-		"ToLower":    strings.ToLower,
-		"Title":      strings.Title,
-		"GoName":     generatego.CamelCase,
-		"TrimPrefix": strings.TrimPrefix,
-	}
-
-	codeTemplate, err := template.New(templName).Funcs(funcMap).Parse(templateString)
+	codeTemplate, err := template.New(templName).Funcs(executor.funcMap).Parse(templateString)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create template")
@@ -329,14 +356,14 @@ func applyTemplate(templBytes []byte, templName string, executor interface{}) (*
 // formatCode takes a string representing golang code and attempts to return a
 // formated copy of that code.  If formatting fails, a warning is logged and
 // the original code is returned.
-func formatCode(code []byte) []byte {
+func formatCode(code []byte) ([]byte, error) {
 	formatted, err := format.Source(code)
 
 	if err != nil {
 		log.WithError(err).Warn("Code formatting error, generated service will not build, outputting unformatted code")
-		// Set formatted to code so at least we get something to examine
-		formatted = code
+		// return code so at least we get something to examine
+		return code, err
 	}
 
-	return formatted
+	return formatted, nil
 }

--- a/gengokit/gengokit_test.go
+++ b/gengokit/gengokit_test.go
@@ -1,0 +1,432 @@
+package gengokit
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/TuneLab/go-truss/deftree"
+
+	templateFileAssets "github.com/TuneLab/go-truss/gengokit/template"
+)
+
+func TestTemplatePathToActual(t *testing.T) {
+
+	pathToWants := map[string]string{
+		"NAME-service/":                "package-service/",
+		"NAME-service/test.gotemplate": "package-service/test.go",
+		"NAME-service/NAME-server":     "package-service/package-server",
+	}
+
+	for path, want := range pathToWants {
+		if got := templatePathToActual(path, "package"); got != want {
+			t.Errorf("\n`%v` got\n`%v` wanted", got, want)
+		}
+	}
+}
+
+func TestNewTemplateExecutor(t *testing.T) {
+	const def = `
+		syntax = "proto3";
+
+		// General package
+		package general;
+
+		import "google/api/annotations.proto";
+
+		// RequestMessage is so foo
+		message RequestMessage {
+		  string input = 1;
+		}
+
+		// ResponseMessage is so bar
+		message ResponseMessage {
+		  string output = 1;
+		}
+
+		// ProtoService is a service
+		service ProtoService {
+		  // ProtoMethod is simple. Like a gopher.
+		  rpc ProtoMethod (RequestMessage) returns (ResponseMessage) {
+			// No {} in path and no body, everything is in the query
+			option (google.api.http) = {
+			  get: "/route"
+			};
+		  }
+		}
+	`
+	dt, err := deftree.NewFromString(def)
+	if err != nil {
+		t.Error(err)
+	}
+
+	const goImportPath = "github.com/TuneLab/go-truss/gengokit"
+
+	te, err := newTemplateExecutor(dt, goImportPath)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if got, want := te.ImportPath, goImportPath+"/general-service"; got != want {
+		t.Errorf("\n`%v` was ImportPath\n`%v` was wanted", got, want)
+	}
+
+	if got, want := te.PackageName, dt.GetName(); got != want {
+		t.Errorf("\n`%v` was PackageName\n`%v` was wanted", got, want)
+	}
+}
+
+func TestGetProtoService(t *testing.T) {
+	const def = `
+		syntax = "proto3";
+
+		// General package
+		package general;
+
+		import "google/api/annotations.proto";
+
+		// RequestMessage is so foo
+		message RequestMessage {
+		  string input = 1;
+		}
+
+		// ResponseMessage is so bar
+		message ResponseMessage {
+		  string output = 1;
+		}
+
+		// ProtoService is a service
+		service ProtoService {
+		  // ProtoMethod is simple. Like a gopher.
+		  rpc ProtoMethod (RequestMessage) returns (ResponseMessage) {
+			// No {} in path and no body, everything is in the query
+			option (google.api.http) = {
+			  get: "/route"
+			};
+		  }
+		}
+	`
+	dt, err := deftree.NewFromString(def)
+	if err != nil {
+		t.Error(err)
+	}
+
+	svc, err := getProtoService(dt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if got, want := svc.GetName(), "ProtoService"; got != want {
+		t.Errorf("\n`%v` was service name\n`%v` was wanted", got, want)
+	}
+
+	if got, want := svc.Methods[0].GetName(), "ProtoMethod"; got != want {
+		t.Errorf("\n`%v` was rpc in service\n`%v` was wanted", got, want)
+	}
+}
+
+func TestApplyTemplateFromPath(t *testing.T) {
+	const def = `
+		syntax = "proto3";
+
+		// General package
+		package general;
+
+		import "google/api/annotations.proto";
+
+		// RequestMessage is so foo
+		message RequestMessage {
+		  string input = 1;
+		}
+
+		// ResponseMessage is so bar
+		message ResponseMessage {
+		  string output = 1;
+		}
+
+		// ProtoService is a service
+		service ProtoService {
+		  // ProtoMethod is simple. Like a gopher.
+		  rpc ProtoMethod (RequestMessage) returns (ResponseMessage) {
+			// No {} in path and no body, everything is in the query 
+			option (google.api.http) = { 
+				get: "/route"
+			};
+		  }
+		}
+	`
+
+	const goImportPath = "github.com/TuneLab/go-truss/gengokit"
+
+	dt, err := deftree.NewFromString(def)
+	if err != nil {
+		t.Error(err)
+	}
+
+	te, err := newTemplateExecutor(dt, goImportPath)
+	if err != nil {
+		t.Error(err)
+	}
+
+	end, err := applyTemplateFromPath("NAME-service/generated/endpoints.gotemplate", te)
+	if err != nil {
+		t.Error(err)
+	}
+
+	endCode, err := ioutil.ReadAll(end)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = formatCode(endCode)
+	if err != nil {
+		t.Error(err)
+	}
+
+}
+
+func TestUpdateServerMethods(t *testing.T) {
+	const def = `
+		syntax = "proto3";
+
+		// General package
+		package general;
+
+		import "google/api/annotations.proto";
+
+		// RequestMessage is so foo
+		message RequestMessage {
+		  string input = 1;
+		}
+
+		// ResponseMessage is so bar
+		message ResponseMessage {
+		  string output = 1;
+		}
+
+		// ProtoService is a service
+		service ProtoService {
+		  // ProtoMethod is simple. Like a gopher.
+		  rpc ProtoMethod (RequestMessage) returns (ResponseMessage) {
+			// No {} in path and no body, everything is in the query 
+			option (google.api.http) = { 
+				get: "/route"
+			};
+		  }
+		}
+	`
+
+	const goImportPath = "github.com/TuneLab/go-truss/gengokit"
+
+	dt, err := deftree.NewFromString(def)
+	if err != nil {
+		t.Error(err)
+	}
+
+	te, err := newTemplateExecutor(dt, goImportPath)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// apply server_handler.go template
+	sh, err := applyTemplateFromPath("NAME-service/handlers/server/server_handler.gotemplate", te)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// read the code off the io.Reader
+	shCode, err := ioutil.ReadAll(sh)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// format the code
+	shCode, err = formatCode(shCode)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// updateServerMethods with the same templateExecutor
+	same, err := updateServerMethods(bytes.NewReader(shCode), te)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// read the new code off the io.Reader
+	sameCode, err := ioutil.ReadAll(same)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// format that new code
+	sameCode, err = formatCode(sameCode)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// make sure the code is the same
+	if bytes.Compare(shCode, sameCode) != 0 {
+		t.Fatalf("\n__BEFORE__\n\n%v\n\n__AFTER\n\n%v\n\nCode before and after updating differs",
+			string(shCode), string(sameCode))
+	}
+}
+
+func TestAllTemplates(t *testing.T) {
+	const goImportPath = "github.com/TuneLab/go-truss/gengokit"
+
+	const def = `
+		syntax = "proto3";
+
+		// General package
+		package general;
+
+		import "google/api/annotations.proto";
+
+		// RequestMessage is so foo
+		message RequestMessage {
+		  string input = 1;
+		}
+
+		// ResponseMessage is so bar
+		message ResponseMessage {
+		  string output = 1;
+		}
+
+		// ProtoService is a service
+		service ProtoService {
+		  // ProtoMethod is simple. Like a gopher.
+		  rpc ProtoMethod (RequestMessage) returns (ResponseMessage) {
+			// No {} in path and no body, everything is in the query 
+			option (google.api.http) = { 
+				get: "/route"
+			};
+		  }
+		}
+	`
+
+	const def2 = `
+		syntax = "proto3";
+
+		// General package
+		package general;
+
+		import "google/api/annotations.proto";
+
+		// RequestMessage is so foo
+		message RequestMessage {
+		  string input = 1;
+		}
+
+		// ResponseMessage is so bar
+		message ResponseMessage {
+		  string output = 1;
+		}
+
+		// ProtoService is a service
+		service ProtoService {
+		  // ProtoMethod is simple. Like a gopher.
+		  rpc ProtoMethod (RequestMessage) returns (ResponseMessage) {
+			// No {} in path and no body, everything is in the query 
+			option (google.api.http) = { 
+				get: "/route"
+			};
+		  }
+		  // ProtoMethodAgain is simple. Like a gopher again.
+		  rpc ProtoMethodAgain (RequestMessage) returns (ResponseMessage) {
+			// No {} in path and no body, everything is in the query 
+			option (google.api.http) = { 
+				get: "/route2"
+			};
+		  }
+		}
+	`
+
+	dt, err := deftree.NewFromString(def)
+	if err != nil {
+		t.Error(err)
+	}
+
+	te, err := newTemplateExecutor(dt, goImportPath)
+	if err != nil {
+		t.Error(err)
+	}
+
+	dt2, err := deftree.NewFromString(def2)
+	if err != nil {
+		t.Error(err)
+	}
+
+	te2, err := newTemplateExecutor(dt2, goImportPath)
+	if err != nil {
+		t.Error(err)
+	}
+
+	for _, templFP := range templateFileAssets.AssetNames() {
+		// skip the partial templates
+		if filepath.Ext(templFP) != ".gotemplate" {
+			continue
+		}
+		prevGenMap := make(map[string]io.Reader)
+
+		firstCode, err := testGenerateResponseFile(templFP, te, prevGenMap)
+		if err != nil {
+			t.Fatalf("%v failed to format on first generation\n\nERROR:\n\n%v\n\nCODE:\n\n%v", templFP, err.Error(), string(firstCode))
+		}
+
+		// store the file to act to pass back to testGenerateResponseFile for second generation
+		prevGenMap[templatePathToActual(templFP, te.PackageName)] = bytes.NewReader(firstCode)
+
+		secondCode, err := testGenerateResponseFile(templFP, te, prevGenMap)
+		if err != nil {
+			t.Fatalf("%v failed to format on second identical generation\n\nERROR:\n\n%v\n\nCODE:\n\n%v", templFP, err.Error(), string(secondCode))
+		}
+
+		if bytes.Compare(firstCode, secondCode) != 0 {
+			t.Fatalf("\n__BEFORE__\n\n%v\n\n__AFTER\n\n%v\n\nCode differs after being regenerated with same definition file",
+				string(firstCode), string(secondCode))
+		}
+
+		// store the file to act to pass back to testGenerateResponseFile for third generation
+		prevGenMap[templatePathToActual(templFP, te.PackageName)] = bytes.NewReader(secondCode)
+
+		// pass in templateExecutor created from def2
+		addRPCCode, err := testGenerateResponseFile(templFP, te2, prevGenMap)
+		if err != nil {
+			t.Fatalf("%v failed to format on third generation with 1 rpc added\n\nERROR:\n\n%v\n\nCODE:\n\n%v", templFP, err.Error(), string(addRPCCode))
+		}
+
+		// store the file to act to pass back to testGenerateResponseFile for forth generation
+		prevGenMap[templatePathToActual(templFP, te.PackageName)] = bytes.NewReader(addRPCCode)
+
+		// pass in templateExecutor create from def1
+		_, err = testGenerateResponseFile(templFP, te, prevGenMap)
+		if err != nil {
+			t.Fatalf("%v failed to format on forth generation with 1 rpc removed\n\nERROR:\n\n%v\n\nCODE:\n\n%v", templFP, err.Error(), string(addRPCCode))
+		}
+	}
+}
+
+func testGenerateResponseFile(templFP string, te *templateExecutor, prevGenMap map[string]io.Reader) ([]byte, error) {
+	// apply server_handler.go template
+	code, err := generateResponseFile(templFP, te, prevGenMap)
+	if err != nil {
+		return nil, err
+	}
+
+	// read the code off the io.Reader
+	codeBytes, err := ioutil.ReadAll(code)
+	if err != nil {
+		return nil, err
+	}
+
+	// format the code
+	codeBytes, err = formatCode(codeBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return codeBytes, nil
+}

--- a/gengokit/gengokit_test.go
+++ b/gengokit/gengokit_test.go
@@ -2,6 +2,7 @@ package gengokit
 
 import (
 	"bytes"
+	"go/format"
 	"io"
 	"io/ioutil"
 	"path/filepath"
@@ -10,7 +11,13 @@ import (
 	"github.com/TuneLab/go-truss/deftree"
 
 	templateFileAssets "github.com/TuneLab/go-truss/gengokit/template"
+
+	log "github.com/Sirupsen/logrus"
 )
+
+func init() {
+	log.SetLevel(log.FatalLevel)
+}
 
 func TestTemplatePathToActual(t *testing.T) {
 
@@ -22,7 +29,7 @@ func TestTemplatePathToActual(t *testing.T) {
 
 	for path, want := range pathToWants {
 		if got := templatePathToActual(path, "package"); got != want {
-			t.Errorf("\n`%v` got\n`%v` wanted", got, want)
+			t.Fatalf("\n`%v` got\n`%v` wanted", got, want)
 		}
 	}
 }
@@ -59,23 +66,22 @@ func TestNewTemplateExecutor(t *testing.T) {
 	`
 	dt, err := deftree.NewFromString(def)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	const goImportPath = "github.com/TuneLab/go-truss/gengokit"
 
 	te, err := newTemplateExecutor(dt, goImportPath)
-
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if got, want := te.ImportPath, goImportPath+"/general-service"; got != want {
-		t.Errorf("\n`%v` was ImportPath\n`%v` was wanted", got, want)
+		t.Fatalf("\n`%v` was ImportPath\n`%v` was wanted", got, want)
 	}
 
 	if got, want := te.PackageName, dt.GetName(); got != want {
-		t.Errorf("\n`%v` was PackageName\n`%v` was wanted", got, want)
+		t.Fatalf("\n`%v` was PackageName\n`%v` was wanted", got, want)
 	}
 }
 
@@ -111,20 +117,20 @@ func TestGetProtoService(t *testing.T) {
 	`
 	dt, err := deftree.NewFromString(def)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	svc, err := getProtoService(dt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if got, want := svc.GetName(), "ProtoService"; got != want {
-		t.Errorf("\n`%v` was service name\n`%v` was wanted", got, want)
+		t.Fatalf("\n`%v` was service name\n`%v` was wanted", got, want)
 	}
 
 	if got, want := svc.Methods[0].GetName(), "ProtoMethod"; got != want {
-		t.Errorf("\n`%v` was rpc in service\n`%v` was wanted", got, want)
+		t.Fatalf("\n`%v` was rpc in service\n`%v` was wanted", got, want)
 	}
 }
 
@@ -163,31 +169,142 @@ func TestApplyTemplateFromPath(t *testing.T) {
 
 	dt, err := deftree.NewFromString(def)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	te, err := newTemplateExecutor(dt, goImportPath)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	end, err := applyTemplateFromPath("NAME-service/generated/endpoints.gotemplate", te)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	endCode, err := ioutil.ReadAll(end)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
-	_, err = formatCode(endCode)
+	_, err = testFormat(endCode)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 }
 
+func TestTrimTemplateExecutorServiceFuncs(t *testing.T) {
+	const goImportPath = "github.com/TuneLab/go-truss/gengokit"
+
+	const def = `
+		syntax = "proto3";
+
+		// General package
+		package general;
+
+		import "google/api/annotations.proto";
+
+		// RequestMessage is so foo
+		message RequestMessage {
+		  string input = 1;
+		}
+
+		// ResponseMessage is so bar
+		message ResponseMessage {
+		  string output = 1;
+		}
+
+		// ProtoService is a service
+		service ProtoService {
+		  // ProtoMethod is simple. Like a gopher.
+		  rpc ProtoMethod (RequestMessage) returns (ResponseMessage) {
+			// No {} in path and no body, everything is in the query
+			option (google.api.http) = {
+				get: "/route"
+			};
+		  }
+		  // ProtoMethodAgain is simple. Like a gopher again.
+		  rpc ProtoMethodAgain (RequestMessage) returns (ResponseMessage) {
+			// No {} in path and no body, everything is in the query
+			option (google.api.http) = {
+				get: "/route2"
+			};
+		  }
+		  // ProtoMethodAgain is simple. Like a gopher again.
+		  rpc ProtoMethodAgainAgain (RequestMessage) returns (ResponseMessage) {
+			// No {} in path and no body, everything is in the query
+			option (google.api.http) = {
+				get: "/route3"
+			};
+		  }
+		}
+	`
+
+	defMethNames := map[string]bool{
+		"ProtoMethod":           true,
+		"ProtoMethodAgain":      true,
+		"ProtoMethodAgainAgain": true,
+	}
+
+	te, err := stringToTemplateExector(def, goImportPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(te.Service.Methods), 3; got != want {
+		t.Fatalf("Got %d methods, wanted %d", got, want)
+	}
+
+	teEmpty := te.trimServiceFuncs(defMethNames)
+	if got, want := len(teEmpty.Service.Methods), 0; got != want {
+		t.Fatalf("Got %d methods, wanted %d", got, want)
+	}
+
+	defMethNames["ProtoMethodAgain"] = false
+	teOnlyAgain := te.trimServiceFuncs(defMethNames)
+	if got, want := len(teOnlyAgain.Service.Methods), 1; got != want {
+		t.Fatalf("Got %d methods, wanted %d", got, want)
+	}
+
+	teOnlyAgainMeths := svcMethodsNames(teOnlyAgain.Service.Methods)
+	got := teOnlyAgainMeths[0]
+	want := "ProtoMethodAgain"
+	if got != want {
+		t.Fatalf("Got `%s` method, wanted `%s`", got, want)
+	}
+
+	emptyMeths := make(map[string]bool, 0)
+	teFull := te.trimServiceFuncs(emptyMeths)
+	if got, want := len(teFull.Service.Methods), 3; got != want {
+		t.Fatalf("Got %d methods, wanted %d", got, want)
+	}
+
+}
+
+func svcMethodsNames(methods []*deftree.ServiceMethod) []string {
+	var mNames []string
+	for _, m := range methods {
+		mNames = append(mNames, m.GetName())
+	}
+
+	return mNames
+}
+
+func stringToTemplateExector(def, importPath string) (*templateExecutor, error) {
+	dt, err := deftree.NewFromString(def)
+	if err != nil {
+		return nil, err
+	}
+
+	te, err := newTemplateExecutor(dt, importPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return te, nil
+
+}
 func TestUpdateServerMethods(t *testing.T) {
 	const def = `
 		syntax = "proto3";
@@ -223,53 +340,53 @@ func TestUpdateServerMethods(t *testing.T) {
 
 	dt, err := deftree.NewFromString(def)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	te, err := newTemplateExecutor(dt, goImportPath)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	// apply server_handler.go template
 	sh, err := applyTemplateFromPath("NAME-service/handlers/server/server_handler.gotemplate", te)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	// read the code off the io.Reader
 	shCode, err := ioutil.ReadAll(sh)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	// format the code
-	shCode, err = formatCode(shCode)
+	shCode, err = testFormat(shCode)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	// updateServerMethods with the same templateExecutor
 	same, err := updateServerMethods(bytes.NewReader(shCode), te)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	// read the new code off the io.Reader
 	sameCode, err := ioutil.ReadAll(same)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	// format that new code
-	sameCode, err = formatCode(sameCode)
+	sameCode, err = testFormat(sameCode)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	// make sure the code is the same
 	if bytes.Compare(shCode, sameCode) != 0 {
-		t.Fatalf("\n__BEFORE__\n\n%v\n\n__AFTER\n\n%v\n\nCode before and after updating differs",
+		t.Fatalf("\n__BEFORE__\n\n%s\n\n__AFTER__\n\n%s\n\nCode before and after updating differs",
 			string(shCode), string(sameCode))
 	}
 }
@@ -346,22 +463,22 @@ func TestAllTemplates(t *testing.T) {
 
 	dt, err := deftree.NewFromString(def)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	te, err := newTemplateExecutor(dt, goImportPath)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	dt2, err := deftree.NewFromString(def2)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	te2, err := newTemplateExecutor(dt2, goImportPath)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	for _, templFP := range templateFileAssets.AssetNames() {
@@ -423,10 +540,22 @@ func testGenerateResponseFile(templFP string, te *templateExecutor, prevGenMap m
 	}
 
 	// format the code
-	codeBytes, err = formatCode(codeBytes)
+	codeBytes, err = testFormat(codeBytes)
 	if err != nil {
 		return nil, err
 	}
 
 	return codeBytes, nil
+}
+
+// testFormat takes a string representing golang code and attempts to return a
+// formated copy of that code.
+func testFormat(code []byte) ([]byte, error) {
+	formatted, err := format.Source(code)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return formatted, nil
 }


### PR DESCRIPTION
`deftree` has a new function `NewFromString` which allows you to create a deftree from just a string literal, which makes testing features against in-line .proto files possible. 

gengokit.go has been refactored in order to use the function to unit test it. So much has been rewritten that the diff makes no sense. Just look at the [new file.](https://github.com/hasAdamr/go-truss/blob/testing/gengokit/gengokit.go)

Unit tests for gengokit.go have been written that test template path renaming, template rendering by path, and rerunning truss with the same definition for server_handler.go. Plus a few more.
