### PR TITLE
Fix http transport panic

### DIFF
--- a/gengokit/httptransport/templates.go
+++ b/gengokit/httptransport/templates.go
@@ -52,7 +52,7 @@ var ClientEncodeTemplate = `
 // the http request (path, query, and body).
 func EncodeHTTP{{$binding.Label}}Request(_ context.Context, r *http.Request, request interface{}) error {
 	fmt.Printf("Encoding request %v\n", request)
-	req := request.(pb.{{GoName $binding.Parent.RequestType}})
+	req := request.(*pb.{{GoName $binding.Parent.RequestType}})
 	_ = req
 
 	// Set the path parameters

--- a/gengokit/httptransport/templates_test.go
+++ b/gengokit/httptransport/templates_test.go
@@ -60,7 +60,7 @@ func TestGenClientEncode(t *testing.T) {
 // the http request (path, query, and body).
 func EncodeHTTPSumZeroRequest(_ context.Context, r *http.Request, request interface{}) error {
 	fmt.Printf("Encoding request %v\n", request)
-	req := request.(pb.SumRequest)
+	req := request.(*pb.SumRequest)
 	_ = req
 
 	// Set the path parameters


### PR DESCRIPTION
Pull request #54 introduced a bug where http transport panics. I know this from using truss. I don't know if this covers all the cases, but it does make truss usable.

I am currently adding http transport to the integration tests to add another layer of production. That pull request should be up soon.
