### PR TITLE
Fix transport tests after removing handler service interface

### DIFF
--- a/truss/_integration-tests/transport/handlers/server/server_handler.go
+++ b/truss/_integration-tests/transport/handlers/server/server_handler.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NewService returns a naïve, stateless implementation of Service.
-func NewService() Service {
+func NewService() pb.TransportPermutationsServer {
 	return transportService{}
 }
 
@@ -62,11 +62,4 @@ func (s transportService) CtxToCtx(ctx context.Context, in *pb.MetaRequest) (*pb
 	}
 
 	return &resp, nil
-}
-
-type Service interface {
-	GetWithQuery(ctx context.Context, in *pb.GetWithQueryRequest) (*pb.GetWithQueryResponse, error)
-	GetWithRepeatedQuery(ctx context.Context, in *pb.GetWithRepeatedQueryRequest) (*pb.GetWithRepeatedQueryResponse, error)
-	PostWithNestedMessageBody(ctx context.Context, in *pb.PostWithNestedMessageBodyRequest) (*pb.PostWithNestedMessageBodyResponse, error)
-	CtxToCtx(ctx context.Context, in *pb.MetaRequest) (*pb.MetaResponse, error)
 }

--- a/truss/_integration-tests/transport/setup_test.go
+++ b/truss/_integration-tests/transport/setup_test.go
@@ -23,7 +23,7 @@ func TestMain(m *testing.M) {
 	var logger log.Logger
 	logger = log.NewNopLogger()
 
-	var service handler.Service
+	var service pb.TransportPermutationsServer
 	{
 		service = handler.NewService()
 	}


### PR DESCRIPTION
These tests copy a handler file that had old generated code in it.

The file was not updated after everything was switched to the .pb.go
interface.