### PR TITLE
Fix multiple protofiles causing http options parsing to catastrophically fail

### DIFF
--- a/svcdef/consolidate_http.go
+++ b/svcdef/consolidate_http.go
@@ -23,6 +23,13 @@ func isOptionalError(err error) bool {
 	return ok && opt.Optional()
 }
 
+func isEOF(err error) bool {
+	if errors.Cause(err) == io.EOF || errors.Cause(err) == io.ErrUnexpectedEOF {
+		return true
+	}
+	return false
+}
+
 // consolidateHTTP accepts a SvcDef and the io.Readers for the proto files
 // comprising the definition. It modifies the SvcDef so that HTTPBindings and
 // their associated HTTPParamters are added to each ServiceMethod. After this,
@@ -39,7 +46,10 @@ func consolidateHTTP(sd *Svcdef, protoFiles []io.Reader) error {
 					"annotations; this is allowed, but will result in HTTP " +
 					"transport not being generated.")
 				return nil
+			} else if isEOF(err) {
+				continue
 			}
+
 			return errors.Wrap(err, "error while parsing http options for the service definition")
 		}
 		assembleHTTPParams(sd.Service, protosvc)

--- a/truss/_integration-tests/cli/cli_test.go
+++ b/truss/_integration-tests/cli/cli_test.go
@@ -41,6 +41,10 @@ func TestBasicTypesWithPBOutFlag(t *testing.T) {
 		"github.com/TuneLab/go-truss/truss/_integration-tests/cli/test-service-definitions/1-basic/pbout")
 }
 
+func TestMultipleFiles(t *testing.T) {
+	testEndToEnd("1-multifile", t)
+}
+
 // Disabled until repeated types are implemented for cliclient
 func _TestRepeatedTypes(t *testing.T) {
 	testEndToEnd("2-repeated", t)

--- a/truss/_integration-tests/cli/test-service-definitions/1-multifile/basic.proto
+++ b/truss/_integration-tests/cli/test-service-definitions/1-multifile/basic.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package TEST;
+
+import "google/api/annotations.proto";
+
+import "imported.proto";
+
+service Basic {
+  rpc GetBasic (BasicTypeRequest) returns (BasicTypeResponse) {
+    option (google.api.http) = {
+      get: "/1"
+    };
+  }
+
+
+  rpc PostBasic (BasicTypeRequest) returns (BasicTypeRequest) {
+    option (google.api.http) = {
+      post: "/2"
+      body: "*"
+    };
+  }
+}
+

--- a/truss/_integration-tests/cli/test-service-definitions/1-multifile/imported.proto
+++ b/truss/_integration-tests/cli/test-service-definitions/1-multifile/imported.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+package TEST;
+
+import "google/api/annotations.proto";
+
+message BasicTypeRequest {
+  double A = 1;
+  float B = 2;
+  int32 C = 3;
+  int64 D = 4;
+  uint32 E = 5;
+  uint64 F = 6;
+  sint32 G = 7;
+  sint64 H = 8;
+  fixed32 I = 9;
+  fixed64 J = 10;
+  sfixed32 K = 11;
+  bool L = 12;
+  string M = 13;
+  // Don't handle bytes currently
+  //  bytes N = 14;
+}
+
+message BasicTypeResponse {
+  double A = 1;
+  float B = 2;
+  int32 C = 3;
+  int64 D = 4;
+  uint32 E = 5;
+  uint64 F = 6;
+  sint32 G = 7;
+  sint64 H = 8;
+  fixed32 I = 9;
+  fixed64 J = 10;
+  sfixed32 K = 11;
+  bool L = 12;
+  string M = 13;
+  // Don't handle bytes currently
+  // bytes N = 14;
+}
+


### PR DESCRIPTION
Pipeline migration introduced this bug, and the test harness did not include a test for multiple protofiles so it was not caught until recently.

@hasLeland added a hotfix branch for this problem. And I have added a simple test on top of it.