### PR TITLE
Fix error in Makefile breaking `make testclean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ test-integration:
 
 # Removes generated code from tests
 testclean:
-	$(MAKE) -C _integration-tests clean
+	$(MAKE) -C cmd/_integration-tests clean


### PR DESCRIPTION
A change was made to the root Makefile causing `make testclean` to fail because of an incorrect directory. This PR fixes that (pretty small) error.