### PR TITLE
Encode errors as json over http transport

### DIFF
--- a/cmd/_integration-tests/transport/handlers/server/server_handler.go
+++ b/cmd/_integration-tests/transport/handlers/server/server_handler.go
@@ -4,6 +4,7 @@ package handler
 // implementation. It also includes service middlewares.
 
 import (
+	"fmt"
 	"golang.org/x/net/context"
 
 	pb "github.com/TuneLab/go-truss/cmd/_integration-tests/transport/transport-service"
@@ -62,4 +63,9 @@ func (s transportService) CtxToCtx(ctx context.Context, in *pb.MetaRequest) (*pb
 	}
 
 	return &resp, nil
+}
+
+// ErrorRPC implements Service.
+func (s transportService) ErrorRPC(ctx context.Context, in *pb.Empty) (*pb.Empty, error) {
+	return nil, fmt.Errorf("This error should be json over http transport")
 }

--- a/cmd/_integration-tests/transport/handlers/server/server_handler.go
+++ b/cmd/_integration-tests/transport/handlers/server/server_handler.go
@@ -4,7 +4,7 @@ package handler
 // implementation. It also includes service middlewares.
 
 import (
-	"fmt"
+	"errors"
 	"golang.org/x/net/context"
 
 	pb "github.com/TuneLab/go-truss/cmd/_integration-tests/transport/transport-service"
@@ -65,7 +65,9 @@ func (s transportService) CtxToCtx(ctx context.Context, in *pb.MetaRequest) (*pb
 	return &resp, nil
 }
 
+var testError error = errors.New("This error should be json over http transport")
+
 // ErrorRPC implements Service.
 func (s transportService) ErrorRPC(ctx context.Context, in *pb.Empty) (*pb.Empty, error) {
-	return nil, fmt.Errorf("This error should be json over http transport")
+	return nil, testError
 }

--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -12,15 +12,12 @@ import (
 
 	// 3d Party
 	"golang.org/x/net/context"
-
 	// This Service
 	pb "github.com/TuneLab/go-truss/cmd/_integration-tests/transport/transport-service"
 	httpclient "github.com/TuneLab/go-truss/cmd/_integration-tests/transport/transport-service/generated/client/http"
 
 	"github.com/pkg/errors"
 )
-
-// httpTestServer
 
 var httpAddr string
 
@@ -65,7 +62,7 @@ func TestGetWithQueryRequest(t *testing.T) {
 
 		err = json.Unmarshal(respBytes, &resp)
 		if err != nil {
-			t.Fatal(errors.Wrapf(err, "json error, got json: %q", string(respBytes)))
+			t.Fatal(errors.Wrapf(err, "json error, got response: %q", string(respBytes)))
 		}
 
 		if resp.V != want {
@@ -115,7 +112,7 @@ func TestGetWithRepeatedQueryRequest(t *testing.T) {
 
 		err = json.Unmarshal(respBytes, &resp)
 		if err != nil {
-			t.Fatal(errors.Wrapf(err, "json error, got json: %q", string(respBytes)))
+			t.Fatal(errors.Wrapf(err, "json error, got response: %q", string(respBytes)))
 		}
 
 		if resp.V != want {
@@ -174,7 +171,7 @@ func TestPostWithNestedMessageBodyRequest(t *testing.T) {
 
 		err = json.Unmarshal(respBytes, &resp)
 		if err != nil {
-			t.Fatal(errors.Wrapf(err, "json error, got json: %q", string(respBytes)))
+			t.Fatal(errors.Wrapf(err, "json error, got response: %q", string(respBytes)))
 		}
 
 		if resp.V != want {
@@ -234,13 +231,34 @@ func TestCtxToCtxViaHTTPHeaderRequest(t *testing.T) {
 
 	err = json.Unmarshal(respBytes, &resp)
 	if err != nil {
-		t.Fatal(errors.Wrapf(err, "json error, got json: %q", string(respBytes)))
+		t.Fatal(errors.Wrapf(err, "json error, got response: %q", string(respBytes)))
 	}
 
 	if resp.V != value {
 		t.Fatalf("Expect: %q, got %q", value, resp.V)
 	}
+}
 
+func TestErrorRPCReturnsJsonError(t *testing.T) {
+	req, err := http.NewRequest("GET", httpAddr+"/"+"error", strings.NewReader(""))
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "cannot construct http request"))
+	}
+
+	respBytes, err := testHTTPRequest(req)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "cannot make http request"))
+	}
+
+	jsonOut := make(map[string]interface{})
+	err = json.Unmarshal(respBytes, &jsonOut)
+	if err != nil {
+		t.Fatal(errors.Wrapf(err, "json error, got response: %q", string(respBytes)))
+	}
+
+	if jsonOut["error"] == nil {
+		t.Fatal("http transport did not send error as json")
+	}
 }
 
 // Helpers

--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -239,7 +239,7 @@ func TestCtxToCtxViaHTTPHeaderRequest(t *testing.T) {
 	}
 }
 
-func TestErrorRPCReturnsJsonError(t *testing.T) {
+func TestErrorRPCReturnsJSONError(t *testing.T) {
 	req, err := http.NewRequest("GET", httpAddr+"/"+"error", strings.NewReader(""))
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "cannot construct http request"))

--- a/cmd/_integration-tests/transport/setup_test.go
+++ b/cmd/_integration-tests/transport/setup_test.go
@@ -33,12 +33,14 @@ func TestMain(m *testing.M) {
 	getWithRepeatedQueryE := svc.MakeGetWithRepeatedQueryEndpoint(service)
 	postWithNestedMessageBodyE := svc.MakePostWithNestedMessageBodyEndpoint(service)
 	ctxToCtxE := svc.MakeCtxToCtxEndpoint(service)
+	errorRPCE := svc.MakeErrorRPCEndpoint(service)
 
 	endpoints := svc.Endpoints{
 		GetWithQueryEndpoint:              getWithQueryE,
 		GetWithRepeatedQueryEndpoint:      getWithRepeatedQueryE,
 		PostWithNestedMessageBodyEndpoint: postWithNestedMessageBodyE,
 		CtxToCtxEndpoint:                  ctxToCtxE,
+		ErrorRPCEndpoint:                  errorRPCE,
 	}
 
 	ctx := context.Background()

--- a/cmd/_integration-tests/transport/transport-test.proto
+++ b/cmd/_integration-tests/transport/transport-test.proto
@@ -27,7 +27,14 @@ service TransportPermutations {
       body: "*"
     };
   }
+  rpc ErrorRPC (Empty) returns (Empty) {
+    option (google.api.http) = {
+      get: "/error"
+    };
+  }
 }
+
+message Empty {}
 
 message GetWithQueryRequest {
   int64 A = 1;

--- a/gengokit/httptransport/templates.go
+++ b/gengokit/httptransport/templates.go
@@ -231,6 +231,7 @@ func MakeHTTPHandler(ctx context.Context, endpoints Endpoints, logger log.Logger
 	{{- if .HTTPHelper.Methods}}
 		serverOptions := []httptransport.ServerOption{
 			httptransport.ServerBefore(headersToContext),
+			httptransport.ServerErrorEncoder(errorEncoder),
 		}
 	{{- end }}
 	m := http.NewServeMux()


### PR DESCRIPTION
[+1 line for actual change.](https://github.com/TuneLab/go-truss/compare/master...hasAdamr:encode-all-errors-json?expand=1#diff-0fe7c6aec1f529107babf5f63bddb542R234)

Plus test to make sure the change persists.

Errors now go across the wire as json with the key "`error`".