### PR TITLE
Fix broken requests for paths with capital letters

### DIFF
--- a/cmd/_integration-tests/transport/handlers/server/server_handler.go
+++ b/cmd/_integration-tests/transport/handlers/server/server_handler.go
@@ -65,6 +65,15 @@ func (s transportService) CtxToCtx(ctx context.Context, in *pb.MetaRequest) (*pb
 	return &resp, nil
 }
 
+//  GetWithCapsPath implements Service
+func (s transportService) GetWithCapsPath(ctx context.Context, in *pb.GetWithQueryRequest) (*pb.GetWithQueryResponse, error) {
+	response := pb.GetWithQueryResponse{
+		V: in.A + in.B,
+	}
+
+	return &response, nil
+}
+
 var testError error = errors.New("This error should be json over http transport")
 
 // ErrorRPC implements Service.

--- a/cmd/_integration-tests/transport/setup_test.go
+++ b/cmd/_integration-tests/transport/setup_test.go
@@ -33,6 +33,7 @@ func TestMain(m *testing.M) {
 	getWithRepeatedQueryE := svc.MakeGetWithRepeatedQueryEndpoint(service)
 	postWithNestedMessageBodyE := svc.MakePostWithNestedMessageBodyEndpoint(service)
 	ctxToCtxE := svc.MakeCtxToCtxEndpoint(service)
+	getWithCapsPathE := svc.MakeGetWithCapsPathEndpoint(service)
 	errorRPCE := svc.MakeErrorRPCEndpoint(service)
 
 	endpoints := svc.Endpoints{
@@ -40,6 +41,7 @@ func TestMain(m *testing.M) {
 		GetWithRepeatedQueryEndpoint:      getWithRepeatedQueryE,
 		PostWithNestedMessageBodyEndpoint: postWithNestedMessageBodyE,
 		CtxToCtxEndpoint:                  ctxToCtxE,
+		GetWithCapsPathEndpoint:           getWithCapsPathE,
 		ErrorRPCEndpoint:                  errorRPCE,
 	}
 

--- a/cmd/_integration-tests/transport/transport-test.proto
+++ b/cmd/_integration-tests/transport/transport-test.proto
@@ -27,6 +27,11 @@ service TransportPermutations {
       body: "*"
     };
   }
+  rpc GetWithCapsPath(GetWithQueryRequest) returns (GetWithQueryResponse) {
+    option (google.api.http) = {
+      get: "/get/With/CapsPath"
+    };
+  }
   rpc ErrorRPC (Empty) returns (Empty) {
     option (google.api.http) = {
       get: "/error"

--- a/gengokit/httptransport/templates.go
+++ b/gengokit/httptransport/templates.go
@@ -238,7 +238,7 @@ func MakeHTTPHandler(ctx context.Context, endpoints Endpoints, logger log.Logger
 
 	{{range $method := .HTTPHelper.Methods}}
 		{{range $binding := $method.Bindings}}
-			m.Handle("{{ToLower $binding.BasePath}}", httptransport.NewServer(
+			m.Handle("{{$binding.BasePath}}", httptransport.NewServer(
 				ctx,
 				endpoints.{{$method.Name}}Endpoint,
 				HttpDecodeLogger(DecodeHTTP{{$binding.Label}}Request, logger),
@@ -394,7 +394,7 @@ func New(instance string, options ...ClientOption) (pb.{{GoName .Service.Name}}S
 			{
 				{{$binding.Label}}Endpoint = httptransport.NewClient(
 					"{{$binding.Verb}}",
-					copyURL(u, "{{ToLower $binding.BasePath}}"),
+					copyURL(u, "{{$binding.BasePath}}"),
 					svc.EncodeHTTP{{$binding.Label}}Request,
 					svc.DecodeHTTP{{$method.Name}}Response,
 					clientOptions...,

--- a/gengokit/template/template.go
+++ b/gengokit/template/template.go
@@ -231,7 +231,7 @@ func nameServiceGeneratedTransport_httpGotemplate() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "NAME-service/generated/transport_http.gotemplate", size: 105, mode: os.FileMode(436), modTime: time.Unix(1477930115, 0)}
+	info := bindataFileInfo{name: "NAME-service/generated/transport_http.gotemplate", size: 105, mode: os.FileMode(436), modTime: time.Unix(1479328586, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -251,7 +251,7 @@ func nameServiceHandlersServerServer_handlerGotemplate() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "NAME-service/handlers/server/server_handler.gotemplate", size: 770, mode: os.FileMode(436), modTime: time.Unix(1478128977, 0)}
+	info := bindataFileInfo{name: "NAME-service/handlers/server/server_handler.gotemplate", size: 770, mode: os.FileMode(436), modTime: time.Unix(1479328586, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
This is a fix for paths with capital letters not being properly handled by the server, with a test for this behavior. For example, if an rpc has an http binding to a path:

    /some/Path/With/Caps

The bug was that a client would make a request to the correct path `/some/Path/With/Caps`, but the server would register this method to a lowercased version of this path, `/some/path/with/caps`.

This is a fix for the above mis-behavior.