### PR TITLE
Refactor to remove truss.NamedReadWriter complexity

### DIFF
--- a/gendoc/gendoc.go
+++ b/gendoc/gendoc.go
@@ -3,14 +3,16 @@
 package gendoc
 
 import (
+	"io"
+	"strings"
+
 	"github.com/TuneLab/go-truss/deftree"
-	"github.com/TuneLab/go-truss/truss"
 )
 
 // GenerateDocs accepts a deftree that represents an ast of a group of
-// protofiles and returns a []truss.SimpleFile that represents a relative
+// protofiles and returns map[string]io.Reader that represents a relative
 // filestructure of generated docs
-func GenerateDocs(dt deftree.Deftree) []truss.NamedReadWriter {
+func GenerateDocs(dt deftree.Deftree) map[string]io.Reader {
 	response := ""
 
 	microDef, ok := dt.(*deftree.MicroserviceDefinition)
@@ -20,13 +22,8 @@ func GenerateDocs(dt deftree.Deftree) []truss.NamedReadWriter {
 		response = "Error, could not cast Deftree to MicroserviceDefinition"
 	}
 
-	var file truss.SimpleFile
-
-	file.Path = dt.GetName() + "-service/docs/docs.md"
-	file.Write([]byte(response))
-
-	var files []truss.NamedReadWriter
-	files = append(files, &file)
+	files := make(map[string]io.Reader)
+	files[dt.GetName()+"-service/docs/docs.md"] = strings.NewReader(response)
 
 	return files
 }

--- a/gengokit/generator/gen.go
+++ b/gengokit/generator/gen.go
@@ -46,7 +46,7 @@ func GenerateGokit(sd *svcdef.Svcdef, conf gengokit.Config) (map[string]io.Reade
 // based on path and if that file was generated previously. It accepts a
 // template path to render, a templateExecutor to apply to the template, and a
 // map of paths to files for the previous generation. It returns a
-// io.Reader representing the generated file
+// io.Reader representing the generated file.
 func generateResponseFile(templFP string, data *gengokit.Data, prevFile io.Reader) (io.Reader, error) {
 	var genCode io.Reader
 	var err error

--- a/gengokit/generator/gen_test.go
+++ b/gengokit/generator/gen_test.go
@@ -232,7 +232,7 @@ func TestAllTemplates(t *testing.T) {
 	for _, templFP := range templateFileAssets.AssetNames() {
 		var prev io.Reader
 
-		firstCode, err := testGenerateResponseFile(data1, prev, templFP)
+		firstCode, err := testGenerateResponseFile(templFP, data1, prev)
 		if err != nil {
 			t.Fatalf("%s failed to format on first generation\n\nERROR:\n\n%s\n\nCODE:\n\n%s", templFP, err, firstCode)
 		}
@@ -240,7 +240,7 @@ func TestAllTemplates(t *testing.T) {
 		// store the file to pass back to testGenerateResponseFile for second generation
 		prev = strings.NewReader(firstCode)
 
-		secondCode, err := testGenerateResponseFile(data1, prev, templFP)
+		secondCode, err := testGenerateResponseFile(templFP, data1, prev)
 		if err != nil {
 			t.Fatalf("%s failed to format on second identical generation\n\nERROR: %s\nCODE:\n\n%s",
 				templFP, err, secondCode)
@@ -254,7 +254,7 @@ func TestAllTemplates(t *testing.T) {
 		prev = strings.NewReader(secondCode)
 
 		// pass in data2 created from def2
-		addRPCCode, err := testGenerateResponseFile(data2, prev, templFP)
+		addRPCCode, err := testGenerateResponseFile(templFP, data2, prev)
 		if err != nil {
 			t.Fatalf("%s failed to format on third generation with 1 rpc added\n\nERROR: %s\nCODE:\n\n%s",
 				templFP, err, addRPCCode)
@@ -264,7 +264,7 @@ func TestAllTemplates(t *testing.T) {
 		prev = strings.NewReader(addRPCCode)
 
 		// pass in data1  create from def1
-		_, err = testGenerateResponseFile(data1, prev, templFP)
+		_, err = testGenerateResponseFile(templFP, data1, prev)
 		if err != nil {
 			t.Fatalf("%s failed to format on fourth generation with 1 rpc removed\n\nERROR: %s\nCODE:\n\n%s",
 				templFP, err, addRPCCode)
@@ -447,8 +447,8 @@ func diff(a, b string) string {
 // string which it returns as this logic needs to be repeated in tests. In
 // addition this function will return an error if the code fails to format,
 // while generateResponseFile will not.
-func testGenerateResponseFile(data *gengokit.Data, prev io.Reader, templFP string) (string, error) {
-	code, err := generateResponseFile(data, prev, templFP)
+func testGenerateResponseFile(templPath string, data *gengokit.Data, prev io.Reader) (string, error) {
+	code, err := generateResponseFile(templPath, data, prev)
 	if err != nil {
 		return "", err
 	}

--- a/gengokit/gengokit.go
+++ b/gengokit/gengokit.go
@@ -12,7 +12,6 @@ import (
 	"github.com/TuneLab/go-truss/gengokit/clientarggen"
 	"github.com/TuneLab/go-truss/gengokit/httptransport"
 	"github.com/TuneLab/go-truss/svcdef"
-	"github.com/TuneLab/go-truss/truss"
 )
 
 type Renderable interface {
@@ -23,7 +22,7 @@ type Config struct {
 	GoPackage string
 	PBPackage string
 
-	PreviousFiles []truss.NamedReadWriter
+	PreviousFiles map[string]io.Reader
 }
 
 // FuncMap contains a series of utility functions to be passed into

--- a/truss/config.go
+++ b/truss/config.go
@@ -1,5 +1,7 @@
 package truss
 
+import "io"
+
 // Config defines the inputs to a truss service generation
 type Config struct {
 	// The first path in $GOPATH
@@ -15,5 +17,5 @@ type Config struct {
 	// The paths to each of the .proto files truss is being run against
 	DefPaths []string
 	// The files of a previously generated service, may be nil
-	PrevGen []NamedReadWriter
+	PrevGen map[string]io.Reader
 }


### PR DESCRIPTION
This pull removes the `truss.NamedReadWriter` interface and `truss.SimpleFile` struct. **No functional change**

This interface was originally because we hoped that `os.File` would satisfy this interface, though the `Name()` method of `os.File` would not work correctly.

It is replaced with a `map[string]io.Reader` which represents a relative path on disk to the service directory to file contents. It is used as the structure for both reading in files and how code generating packages output files to write. 

It is overall cleaner as it removes a custom type and I hope reflects a slightly better understanding of `io.Reader`'s. 