### PR TITLE
Move flag Parse to main so flags can be defined by packages

### DIFF
--- a/cmd/truss/main.go
+++ b/cmd/truss/main.go
@@ -57,7 +57,9 @@ func init() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [options] <protofile>...\n", binName)
 		flag.PrintDefaults()
 	}
+}
 
+func main() {
 	flag.Parse()
 
 	if len(flag.Args()) == 0 {
@@ -70,9 +72,7 @@ func init() {
 	if *verboseFlag {
 		log.SetLevel(log.DebugLevel)
 	}
-}
 
-func main() {
 	cfg, err := parseInput()
 	exitIfError(errors.Wrap(err, "cannot parse input"))
 


### PR DESCRIPTION
If flag.Parse is called in main than the init function of imported packages can
define flags that will be picked up by the truss binary.

See this comment in the flags package.
https://golang.org/src/flag/example_test.go?s=2478:2520#L79

Also the diff is amazing.