### PR TITLE
Slightly improved error messages

### DIFF
--- a/cmd/truss/main.go
+++ b/cmd/truss/main.go
@@ -227,7 +227,7 @@ func parseServiceDefinition(cfg *truss.Config) (deftree.Deftree, *svcdef.Svcdef,
 	// Create the svcdef
 	sd, err := svcdef.New(pbgoFiles, pbFiles)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "failed to create service definition")
+		return nil, nil, errors.Wrapf(err, "failed to create service definition; did you pass ALL the protobuf files to truss?")
 	}
 
 	// Create the Deftree

--- a/cmd/truss/main.go
+++ b/cmd/truss/main.go
@@ -195,16 +195,15 @@ func parseServiceDefinition(cfg *truss.Config) (deftree.Deftree, *svcdef.Svcdef,
 		return nil, nil, errors.Wrap(err, "cannot create .pb.go files")
 	}
 
-	// Open all .pb.go files and store in slice to be passed to svcdef.New()
-	//var openFiles func([]string) ([]io.Reader, error)
-	openFiles := func(paths []string) ([]io.Reader, error) {
-		rv := []io.Reader{}
+	// Open all .pb.go files and store in map to be passed to svcdef.New()
+	openFiles := func(paths []string) (map[string]io.Reader, error) {
+		rv := map[string]io.Reader{}
 		for _, p := range paths {
 			reader, err := os.Open(p)
 			if err != nil {
 				return nil, errors.Wrapf(err, "cannot open file %q", p)
 			}
-			rv = append(rv, reader)
+			rv[p] = reader
 		}
 		return rv, nil
 	}
@@ -228,7 +227,7 @@ func parseServiceDefinition(cfg *truss.Config) (deftree.Deftree, *svcdef.Svcdef,
 	// Create the svcdef
 	sd, err := svcdef.New(pbgoFiles, pbFiles)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "cannot create svcdef")
+		return nil, nil, errors.Wrapf(err, "failed to create service definition")
 	}
 
 	// Create the Deftree

--- a/svcdef/consolidate_http.go
+++ b/svcdef/consolidate_http.go
@@ -36,7 +36,7 @@ func isEOF(err error) bool {
 // each `HTTPBinding` will have a populated list of all the http parameters
 // that that binding requires, where that parameter should be located, and the
 // type of each parameter.
-func consolidateHTTP(sd *Svcdef, protoFiles []io.Reader) error {
+func consolidateHTTP(sd *Svcdef, protoFiles map[string]io.Reader) error {
 	for _, pfile := range protoFiles {
 		lex := svcparse.NewSvcLexer(pfile)
 		protosvc, err := svcparse.ParseService(lex)

--- a/svcdef/consolidate_http_test.go
+++ b/svcdef/consolidate_http_test.go
@@ -84,7 +84,7 @@ service Map {
   }
 }`
 	// From code, build our SvcDef
-	sd, err := New([]io.Reader{strings.NewReader(goCode)}, []io.Reader{strings.NewReader(protoCode)})
+	sd, err := New(map[string]io.Reader{"/tmp/notreal": strings.NewReader(goCode)}, map[string]io.Reader{"/tmp/alsonotreal": strings.NewReader(protoCode)})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/svcdef/newfromstring.go
+++ b/svcdef/newfromstring.go
@@ -44,7 +44,13 @@ func NewFromString(def string, gopath []string) (*Svcdef, error) {
 	}
 	pbgo := string(buf)
 
-	sd, err := New([]io.Reader{strings.NewReader(pbgo)}, []io.Reader{strings.NewReader(def)})
+	pbgoMap := map[string]io.Reader{
+		"/tmp/doesntexist.pb.go": strings.NewReader(pbgo),
+	}
+	pFileMap := map[string]io.Reader{
+		"/tmp/doesntexist.proto": strings.NewReader(def),
+	}
+	sd, err := New(pbgoMap, pFileMap)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create new svcdef from pb.go and definition")
 	}

--- a/svcdef/recopy-testdata.sh
+++ b/svcdef/recopy-testdata.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+mkdir scrap/ 
+cd scrap/ 
+cp ../test-proto.txt ./svc.proto
+truss *.proto
+cp TEST-service/svc.pb.go ../test-go.txt
+cd ../
+rm -r scrap

--- a/svcdef/recopy-testdata.sh
+++ b/svcdef/recopy-testdata.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-mkdir scrap/ 
-cd scrap/ 
-cp ../test-proto.txt ./svc.proto
-truss *.proto
-cp TEST-service/svc.pb.go ../test-go.txt
-cd ../
-rm -r scrap

--- a/svcdef/svcdef_test.go
+++ b/svcdef/svcdef_test.go
@@ -17,7 +17,7 @@ func TestSvcdef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sd, err := New([]io.Reader{gf}, []io.Reader{pf})
+	sd, err := New(map[string]io.Reader{"./test-go.txt": gf}, map[string]io.Reader{"./test-proto.txt": pf})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ type NestedTypeRequest struct {
 	B []*NestedMessageB
 	C EnumType
 }`
-	sd, err := New([]io.Reader{strings.NewReader(caseCode)}, nil)
+	sd, err := New(map[string]io.Reader{"/tmp/notreal": strings.NewReader(caseCode)}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +109,7 @@ type MsgWithMap struct {
 	Beta map[int64]*NestedMessageC
 }
 `
-	sd, err := New([]io.Reader{strings.NewReader(caseCode)}, nil)
+	sd, err := New(map[string]io.Reader{"/tmp/notreal": strings.NewReader(caseCode)}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is some work to slightly improve error emssages from `svcdef` where possible, and to add one suggestion for the potential source of these errors.

Specifically, `svcdef` will now include file path and line numbers in the error messages it returns, and there is a suggestion that you ensure all protobuf files where passed to truss.