### PR TITLE
Fix #127 - Error on incomplete path parameters

### DIFF
--- a/cmd/_integration-tests/transport/handlers/server/server_handler.go
+++ b/cmd/_integration-tests/transport/handlers/server/server_handler.go
@@ -66,12 +66,20 @@ func (s transportService) CtxToCtx(ctx context.Context, in *pb.MetaRequest) (*pb
 	return &resp, nil
 }
 
-//  GetWithCapsPath implements Service
+// GetWithCapsPath implements Service.
 func (s transportService) GetWithCapsPath(ctx context.Context, in *pb.GetWithQueryRequest) (*pb.GetWithQueryResponse, error) {
 	response := pb.GetWithQueryResponse{
 		V: in.A + in.B,
 	}
 
+	return &response, nil
+}
+
+// GetWithPathParams implements Service.
+func (s transportService) GetWithPathParams(ctx context.Context, in *pb.GetWithQueryRequest) (*pb.GetWithQueryResponse, error) {
+	response := pb.GetWithQueryResponse{
+		V: in.A + in.B,
+	}
 	return &response, nil
 }
 

--- a/cmd/_integration-tests/transport/setup_test.go
+++ b/cmd/_integration-tests/transport/setup_test.go
@@ -34,6 +34,7 @@ func TestMain(m *testing.M) {
 	postWithNestedMessageBodyE := svc.MakePostWithNestedMessageBodyEndpoint(service)
 	ctxToCtxE := svc.MakeCtxToCtxEndpoint(service)
 	getWithCapsPathE := svc.MakeGetWithCapsPathEndpoint(service)
+	getWithPathParamsE := svc.MakeGetWithPathParamsEndpoint(service)
 	errorRPCE := svc.MakeErrorRPCEndpoint(service)
 
 	endpoints := svc.Endpoints{
@@ -42,6 +43,7 @@ func TestMain(m *testing.M) {
 		PostWithNestedMessageBodyEndpoint: postWithNestedMessageBodyE,
 		CtxToCtxEndpoint:                  ctxToCtxE,
 		GetWithCapsPathEndpoint:           getWithCapsPathE,
+		GetWithPathParamsEndpoint:         getWithPathParamsE,
 		ErrorRPCEndpoint:                  errorRPCE,
 	}
 

--- a/cmd/_integration-tests/transport/transport-test.proto
+++ b/cmd/_integration-tests/transport/transport-test.proto
@@ -32,6 +32,11 @@ service TransportPermutations {
       get: "/get/With/CapsPath"
     };
   }
+  rpc GetWithPathParams(GetWithQueryRequest) returns (GetWithQueryResponse) {
+    option (google.api.http) = {
+    get: "/path/{A}/{B}"
+    };
+  }
   rpc ErrorRPC (Empty) returns (Empty) {
     option (google.api.http) = {
       get: "/error"

--- a/cmd/_integration-tests/transport/transport-test.proto
+++ b/cmd/_integration-tests/transport/transport-test.proto
@@ -34,7 +34,7 @@ service TransportPermutations {
   }
   rpc GetWithPathParams(GetWithQueryRequest) returns (GetWithQueryResponse) {
     option (google.api.http) = {
-    get: "/path/{A}/{B}"
+      get: "/path/{A}/{B}"
     };
   }
   rpc ErrorRPC (Empty) returns (Empty) {

--- a/gengokit/httptransport/embeddable_funcs.go
+++ b/gengokit/httptransport/embeddable_funcs.go
@@ -1,7 +1,6 @@
 package httptransport
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -24,13 +23,10 @@ func PathParams(url string, urlTmpl string) (map[string]string, error) {
 	rv := map[string]string{}
 	pmp := BuildParamMap(urlTmpl)
 
-	tmplLen := len(strings.Split(strings.TrimRight(urlTmpl, "/"), "/"))
-	partsLen := len(strings.Split(strings.TrimRight(url, "/"), "/"))
-	if tmplLen != partsLen {
-		expected := tmplLen
-		found := partsLen
-		msg := fmt.Sprintf("Expected a path containing %v parts, provided path contains %v parts", expected, found)
-		return nil, errors.New(msg)
+	expectedLen := len(strings.Split(strings.TrimRight(urlTmpl, "/"), "/"))
+	recievedLen := len(strings.Split(strings.TrimRight(url, "/"), "/"))
+	if expectedLen != recievedLen {
+		return nil, fmt.Errorf("Expected a path containing %d parts, provided path contains %d parts", expectedLen, recievedLen)
 	}
 
 	parts := strings.Split(url, "/")

--- a/gengokit/httptransport/embeddable_funcs.go
+++ b/gengokit/httptransport/embeddable_funcs.go
@@ -1,6 +1,8 @@
 package httptransport
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"strings"
 )
@@ -21,6 +23,15 @@ import (
 func PathParams(url string, urlTmpl string) (map[string]string, error) {
 	rv := map[string]string{}
 	pmp := BuildParamMap(urlTmpl)
+
+	tmplLen := len(strings.Split(strings.TrimRight(urlTmpl, "/"), "/"))
+	partsLen := len(strings.Split(strings.TrimRight(url, "/"), "/"))
+	if tmplLen != partsLen {
+		expected := tmplLen
+		found := partsLen
+		msg := fmt.Sprintf("Expected a path containing %v parts, provided path contains %v parts", expected, found)
+		return nil, errors.New(msg)
+	}
 
 	parts := strings.Split(url, "/")
 	for k, v := range pmp {

--- a/gengokit/httptransport/httptransport_test.go
+++ b/gengokit/httptransport/httptransport_test.go
@@ -106,6 +106,7 @@ func TestPathParams(t *testing.T) {
 		{"/1234", "/{a}", "a", "1234"},
 		{"/v1/1234", "/v1/{a}", "a", "1234"},
 		{"/v1/user/5/home", "/v1/user/{userid}/home", "userid", "5"},
+		{"/blah/", "/{a}", "a", "blah"},
 	}
 
 	for _, test := range cases {
@@ -119,6 +120,23 @@ func TestPathParams(t *testing.T) {
 			}
 		} else {
 			t.Errorf("PathParams didn't return map containing field '%v'\n", test.field)
+		}
+	}
+}
+
+// Test that the PathParams function will correctly fail
+func TestPathParamsFailure(t *testing.T) {
+	var cases = []struct {
+		url, tmpl string
+	}{
+		{"/too/few/params", "/{a}/{b}/{c}/{d}"},
+		{"/way/too/many/params", "/{a}"},
+	}
+
+	for _, test := range cases {
+		_, err := PathParams(test.url, test.tmpl)
+		if err == nil {
+			t.Errorf("PathParams returned no error when it should have returned an error on case '%+v'\n", test)
 		}
 	}
 }

--- a/gengokit/httptransport/templates.go
+++ b/gengokit/httptransport/templates.go
@@ -118,6 +118,15 @@ func PathParams(url string, urlTmpl string) (map[string]string, error) {
 	rv := map[string]string{}
 	pmp := BuildParamMap(urlTmpl)
 
+	tmplLen := len(strings.Split(strings.TrimRight(urlTmpl, "/"), "/"))
+	partsLen := len(strings.Split(strings.TrimRight(url, "/"), "/"))
+	if tmplLen != partsLen {
+		expected := tmplLen
+		found := partsLen
+		msg := fmt.Sprintf("Expected a path containing %v parts, provided path contains %v parts", expected, found)
+		return nil, errors.New(msg)
+	}
+
 	parts := strings.Split(url, "/")
 	for k, v := range pmp {
 		rv[k] = parts[v]
@@ -318,7 +327,7 @@ func EncodeHTTPGenericResponse(_ context.Context, w http.ResponseWriter, respons
 	return json.NewEncoder(w).Encode(response)
 }
 
-// Helper functions 
+// Helper functions
 
 {{.HTTPHelper.PathParamsBuilder}}
 

--- a/gengokit/httptransport/templates.go
+++ b/gengokit/httptransport/templates.go
@@ -118,13 +118,10 @@ func PathParams(url string, urlTmpl string) (map[string]string, error) {
 	rv := map[string]string{}
 	pmp := BuildParamMap(urlTmpl)
 
-	tmplLen := len(strings.Split(strings.TrimRight(urlTmpl, "/"), "/"))
-	partsLen := len(strings.Split(strings.TrimRight(url, "/"), "/"))
-	if tmplLen != partsLen {
-		expected := tmplLen
-		found := partsLen
-		msg := fmt.Sprintf("Expected a path containing %v parts, provided path contains %v parts", expected, found)
-		return nil, errors.New(msg)
+	expectedLen := len(strings.Split(strings.TrimRight(urlTmpl, "/"), "/"))
+	recievedLen := len(strings.Split(strings.TrimRight(url, "/"), "/"))
+	if expectedLen != recievedLen {
+		return nil, fmt.Errorf("Expected a path containing %d parts, provided path contains %d parts", expectedLen, recievedLen)
 	}
 
 	parts := strings.Split(url, "/")

--- a/gengokit/httptransport/templates_test.go
+++ b/gengokit/httptransport/templates_test.go
@@ -7,6 +7,11 @@ import (
 	"github.com/TuneLab/go-truss/gengokit/gentesthelper"
 )
 
+// Test that rendering certain templates will ouput the code we expect. The
+// code we expect is either the source code literal defined in each test, or
+// it's the source code of certain actual functions within this package (see
+// embeddable-funcs.go for more info).
+
 func TestGenClientEncode(t *testing.T) {
 	binding := &Binding{
 		Label:        "SumZero",
@@ -201,8 +206,12 @@ func DecodeHTTPSumZeroRequest(_ context.Context, r *http.Request) (interface{}, 
 	}
 }
 
+// Test that all the templated source code is identical to the source code
+// found within the file 'embeddable_funcs.go'.
 func TestHTTPAssistFuncs(t *testing.T) {
 	tmplfncs := FormatCode(HTTPAssistFuncs)
+	// Get the source code for all the functions in the same source file as
+	// the BuildParamMap function
 	source, err := AllFuncSourceCode(BuildParamMap)
 	if err != nil {
 		t.Fatalf("Couldn't get source code of functions: %v", err)


### PR DESCRIPTION
This is a fix for issue #127 so now an error will be returned when there's an incomplete path, instead of just panicking!

In addition to just the fix, I added unit tests for the `PathParams` function within `gengokit/httptransport`, as well as an integration test for this case.