### PR TITLE
[#131] Supress warnings when httpoptions are not defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,16 @@ SHA := $(shell git rev-parse --short=10 HEAD)
 default: truss
 
 dependencies:
-	go get github.com/go-kit/kit
 	go get github.com/TuneLab/go-genproto
 	go get github.com/golang/protobuf/{proto,protoc-gen-go}
+	go get github.com/jteeuwen/go-bindata/...
+	go get -d github.com/go-kit/kit
 
 update-dependencies:
-	go get -u github.com/go-kit/kit
 	go get -u github.com/TuneLab/go-genproto
 	go get -u github.com/golang/protobuf/{proto,protoc-gen-go}
+	go get -u github.com/jteeuwen/go-bindata/...
+	go get -u github.com/go-kit/kit
 
 # Generate go files containing the all template files in []byte form
 gobindata:

--- a/deftree/svcparse/parser.go
+++ b/deftree/svcparse/parser.go
@@ -229,6 +229,10 @@ func ParseMethod(lex *SvcLexer) (*Method, error) {
 	if err != nil {
 		return nil, err
 	}
+	// End of RPC (no httpoptions)
+	if bindings == nil {
+		return nil, nil
+	}
 	toret.HTTPBindings = bindings
 
 	// There should be a semi-colon immediately following all 'option'
@@ -322,11 +326,14 @@ func ParseHttpBindings(lex *SvcLexer) ([]*HTTPBinding, error) {
 			return nil, err
 		}
 		return append(rv, new_opt), nil
+	case val == "}":
+		// End of RPC
+		return nil, nil
 	}
 
-	opt := optionalParseErr("'option' or 'additional_bindings' while parsing options", lex.GetLineNumber(), val)
+	optErr := optionalParseErr("'}', 'option' or 'additional_bindings' while parsing options", lex.GetLineNumber(), val)
 
-	return nil, opt
+	return nil, optErr
 }
 
 func ParseBindingFields(lex *SvcLexer) ([]*Field, error) {


### PR DESCRIPTION
Before if the user did not specify any httpoptions truss would spew a
rather lengthly warning about how http transport would not work. This
change removes those warnings under the assumption if httpoptions are
missing the users probably did so intentionally.

In the case where the annotations needed to parse the httpoptions is not
imported and httpoptions exist. Truss follows existing behavior and dies
immediately.

Resolves #131 