### PR TITLE
Fix #124: Isolate integration test tools locally

### DIFF
--- a/cmd/_integration-tests/Makefile
+++ b/cmd/_integration-tests/Makefile
@@ -13,19 +13,23 @@ all: test
 
 test: clean test-transport test-cli
 
-local-tools:
-	go build -o protoc-gen-truss-protocast github.com/TuneLab/go-truss/cmd/protoc-gen-truss-protocast
+truss:
 	go build -o truss github.com/TuneLab/go-truss/cmd/truss
 
-test-transport: local-tools
+protoc-gen-truss-protocast:
+	go build -o protoc-gen-truss-protocast github.com/TuneLab/go-truss/cmd/protoc-gen-truss-protocast
+
+test-transport: protoc-gen-truss-protocast truss
 	@which truss
 	@printf '$(TRANSPORT_TEST_MSG)'
 	$(MAKE) -C transport
+	rm -f ./truss ./protoc-gen-truss-protocast
 
-test-cli: local-tools
+test-cli: protoc-gen-truss-protocast truss
 	@which truss
 	@printf '$(CLI_TEST_MSG)'
 	go test -v ./cli
+	rm -f ./truss ./protoc-gen-truss-protocast
 
 clean:
 	rm -f ./truss ./protoc-gen-truss-protocast

--- a/cmd/_integration-tests/Makefile
+++ b/cmd/_integration-tests/Makefile
@@ -7,20 +7,28 @@ TRANSPORT_TEST_MSG=\n$(OK_COLOR)Starting transport end to end test:$(END_COLOR_L
 
 CLI_TEST_MSG=\n$(OK_COLOR)Start server and cliclient generate, build, and run test:$(END_COLOR_LINE)
 
+export PATH := $(CURDIR):$(PATH)
 
 all: test
 
 test: clean test-transport test-cli
 
-test-transport:
+local-tools:
+	go build -o protoc-gen-truss-protocast github.com/TuneLab/go-truss/cmd/protoc-gen-truss-protocast
+	go build -o truss github.com/TuneLab/go-truss/cmd/truss
+
+test-transport: local-tools
+	@which truss
 	@printf '$(TRANSPORT_TEST_MSG)'
 	$(MAKE) -C transport
 
-test-cli:
+test-cli: local-tools
+	@which truss
 	@printf '$(CLI_TEST_MSG)'
 	go test -v ./cli
 
 clean:
+	rm -f ./truss ./protoc-gen-truss-protocast
 	go test ./cli -clean
 	$(MAKE) -C transport clean
 


### PR DESCRIPTION
This PR is a basic implementation of the behavior described in issue #124; instead of running integration tests by doing a `go install` of the tools in the repo and *hoping* those tools will then be available in the `$PATH`, we instead install the tools to the a set directory and append that directory to the front of our `$PATH` before running the tests.

This is a somewhat hackish way to ensure the correct `truss` and `protoc-gen-truss-protocast` binaries are used during integration tests, but it works reliably and I couldn't think of another way to do this without a total overhaul ; )