### PR TITLE
Move to CSV-style query params for basic repeated types

### DIFF
--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -89,7 +89,7 @@ func TestGetWithRepeatedQueryRequest(t *testing.T) {
 
 	testHTTP(t, &resp, &expects, nil, "GET", "getwithrepeatedquery?%s=[%d,%d]", "A", A[0], A[1])
 	// csv style
-	//testHTTP(nil, "GET", "getwithrepeatedquery?%s=%d,%d", "A", A[0], A[1])
+	testHTTP(t, &resp, &expects, nil, "GET", "getwithrepeatedquery?%s=%d,%d", "A", A[0], A[1])
 	// multi / golang style
 	//testHTTP(nil, "GET", "getwithrepeatedquery?%s=%d&%s=%d]", "A", A[0], "A", A[1])
 }

--- a/gengokit/httptransport/templates.go
+++ b/gengokit/httptransport/templates.go
@@ -76,13 +76,6 @@ var ClientEncodeTemplate = `
 						return errors.Wrap(err, "failed to marshal req.{{$field.CamelName}}")
 					}
 					strval = string(tmp)
-					{{/* Remove square brackets on the beginning end of basic
-					repeated types after json encoding; allows for CSV-style
-					arguments.*/}}
-					{{if and (and $field.IsBaseType $field.Repeated) (not (Contains $field.GoType "[]byte"))}}
-					strval = strings.TrimSuffix(strval, "]")
-					strval = strings.TrimPrefix(strval, "[")
-					{{- end}}
 					values.Add("{{$field.Name}}", strval)
 				{{else}}
 					values.Add("{{$field.Name}}", fmt.Sprint(req.{{$field.CamelName}}))

--- a/gengokit/httptransport/templates_test.go
+++ b/gengokit/httptransport/templates_test.go
@@ -62,6 +62,8 @@ func TestGenClientEncode(t *testing.T) {
 // the http request (path, query, and body).
 func EncodeHTTPSumZeroRequest(_ context.Context, r *http.Request, request interface{}) error {
 	fmt.Printf("Encoding request %v\n", request)
+	strval := ""
+	_ = strval
 	req := request.(*pb.SumRequest)
 	_ = req
 


### PR DESCRIPTION
This PR changes the behavior of generated clients and servers such that query parameters of basic repeated types will no longer require surrounding brackets. This is done for greater compatibility, as most applications expect the following query string format:

    /some/path?foo=bar,baz

As opposed to the previous behavior:

    /some/path?foo=[bar,baz]

This is also done so that newly-generated clients and servers may be compatible with existing infrastructure, in our case, the `multiverse` project.