### PR TITLE
Fix relative directory flags for --pbout and --svcout

### DIFF
--- a/cmd/_integration-tests/cli/cli_test.go
+++ b/cmd/_integration-tests/cli/cli_test.go
@@ -41,6 +41,18 @@ func TestBasicTypesWithPBOutFlag(t *testing.T) {
 		"github.com/TuneLab/go-truss/cmd/_integration-tests/cli/test-service-definitions/1-basic/pbout")
 }
 
+func TestBasicTypesWithRelPBOutFlag(t *testing.T) {
+	testEndToEnd("1-basic", t,
+		"--pbout",
+		"./pbout")
+}
+
+func TestBasicTypesWithRelSVCOutFlag(t *testing.T) {
+	testEndToEnd("1-basic", t,
+		"--svcout",
+		".")
+}
+
 func TestMultipleFiles(t *testing.T) {
 	testEndToEnd("1-multifile", t)
 }

--- a/cmd/truss/main.go
+++ b/cmd/truss/main.go
@@ -147,7 +147,7 @@ func parseInput() (*truss.Config, error) {
 		if !fileExists(p.Dir) {
 			return nil, errors.Errorf("specified package path for service output directory does not exist: %q", p.Dir)
 		}
-		cfg.ServicePackage = filepath.Join(baseSVCPackage, svcFolderName)
+		cfg.ServicePackage = filepath.Join(p.ImportPath, svcFolderName)
 		cfg.ServicePath = filepath.Join(p.Dir, svcFolderName)
 	}
 	log.WithField("Service Package", cfg.ServicePackage).Debug()
@@ -164,14 +164,14 @@ func parseInput() (*truss.Config, error) {
 		cfg.PBPackage = cfg.ServicePackage
 		cfg.PBPath = cfg.ServicePath
 	} else {
-		cfg.PBPackage = *pbPackageFlag
-		p, err := build.Default.Import(cfg.PBPackage, wd, build.FindOnly)
+		p, err := build.Default.Import(*pbPackageFlag, wd, build.FindOnly)
 		if err != nil {
 			return nil, err
 		}
 		if !fileExists(p.Dir) {
 			return nil, errors.Errorf("specified package path for .pb.go output directory does not exist: %q", p.Dir)
 		}
+		cfg.PBPackage = p.ImportPath
 		cfg.PBPath = p.Dir
 	}
 	log.WithField("PB Package", cfg.PBPackage).Debug()


### PR DESCRIPTION
It seems that relative directories were being put as imports with truss if you used a relative directory as in the `--svcout` or `--pbout` flag. 

So `--svcout ../service` would add imports of the form `../service/truss-service/generated`... Which can cause all kinds of issues.

I have fixed that and have added to a test for reach flag for a relative directory to make sure the that the go tools can always deal with the output of a relative directory flag.