### PR TITLE
Fix incorrect naming of body parameters in client encoding

### DIFF
--- a/cmd/_integration-tests/transport/handlers/server/server_handler.go
+++ b/cmd/_integration-tests/transport/handlers/server/server_handler.go
@@ -83,7 +83,7 @@ func (s transportService) GetWithPathParams(ctx context.Context, in *pb.GetWithQ
 	return &response, nil
 }
 
-// EchoOddNames implements Service. Why do we always put this comment here?
+// EchoOddNames implements Service.
 func (s transportService) EchoOddNames(ctx context.Context, in *pb.OddFieldNames) (*pb.OddFieldNames, error) {
 	return in, nil
 }

--- a/cmd/_integration-tests/transport/handlers/server/server_handler.go
+++ b/cmd/_integration-tests/transport/handlers/server/server_handler.go
@@ -83,6 +83,11 @@ func (s transportService) GetWithPathParams(ctx context.Context, in *pb.GetWithQ
 	return &response, nil
 }
 
+// EchoOddNames implements Service. Why do we always put this comment here?
+func (s transportService) EchoOddNames(ctx context.Context, in *pb.OddFieldNames) (*pb.OddFieldNames, error) {
+	return in, nil
+}
+
 var testError error = errors.New("This error should be json over http transport")
 
 // ErrorRPC implements Service.

--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -158,6 +158,26 @@ func TestCtxToCtxViaHTTPHeaderClient(t *testing.T) {
 	}
 }
 
+func TestEchoOddNamesClient(t *testing.T) {
+	var req pb.OddFieldNames
+	req.CamelCase = 12
+	req.SnakeCase = 24
+	req.XWhy_So_Many_Underscores = 36
+
+	svchttp, err := httpclient.New(httpAddr)
+	if err != nil {
+		t.Fatalf("failed to create httpclient: %q", err)
+	}
+
+	resp, err := svchttp.EchoOddNames(context.Background(), &req)
+	if err != nil {
+		t.Fatalf("httpclient returned error: %q", err)
+	}
+	if !reflect.DeepEqual(resp, &req) {
+		t.Fatalf("Expected req and resp to be identical, instead: \n%+v\n%+v", req, *resp)
+	}
+}
+
 func TestCtxToCtxViaHTTPHeaderRequest(t *testing.T) {
 	var resp pb.MetaResponse
 	var key, value = "Truss-Auth-Header", "SECRET"

--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -158,11 +158,14 @@ func TestCtxToCtxViaHTTPHeaderClient(t *testing.T) {
 	}
 }
 
+// Test different kinds of message field names from protobuf definition.
+// e.g. "CamelCase", "snake_case", "__why_so_many_underscores"
 func TestEchoOddNamesClient(t *testing.T) {
-	var req pb.OddFieldNames
-	req.CamelCase = 12
-	req.SnakeCase = 24
-	req.XWhy_So_Many_Underscores = 36
+	req := pb.OddFieldNames{
+		CamelCase:                12,
+		SnakeCase:                24,
+		XWhy_So_Many_Underscores: 36,
+	}
 
 	svchttp, err := httpclient.New(httpAddr)
 	if err != nil {

--- a/cmd/_integration-tests/transport/setup_test.go
+++ b/cmd/_integration-tests/transport/setup_test.go
@@ -35,6 +35,7 @@ func TestMain(m *testing.M) {
 	ctxToCtxE := svc.MakeCtxToCtxEndpoint(service)
 	getWithCapsPathE := svc.MakeGetWithCapsPathEndpoint(service)
 	getWithPathParamsE := svc.MakeGetWithPathParamsEndpoint(service)
+	echoOddNamesE := svc.MakeEchoOddNamesEndpoint(service)
 	errorRPCE := svc.MakeErrorRPCEndpoint(service)
 
 	endpoints := svc.Endpoints{
@@ -44,6 +45,7 @@ func TestMain(m *testing.M) {
 		CtxToCtxEndpoint:                  ctxToCtxE,
 		GetWithCapsPathEndpoint:           getWithCapsPathE,
 		GetWithPathParamsEndpoint:         getWithPathParamsE,
+		EchoOddNamesEndpoint:              echoOddNamesE,
 		ErrorRPCEndpoint:                  errorRPCE,
 	}
 

--- a/cmd/_integration-tests/transport/transport-test.proto
+++ b/cmd/_integration-tests/transport/transport-test.proto
@@ -37,6 +37,13 @@ service TransportPermutations {
       get: "/path/{A}/{B}"
     };
   }
+  rpc EchoOddNames (OddFieldNames) returns (OddFieldNames) {
+  /* Ensure that strange field names survive the encode/decode phases */
+    option (google.api.http) = {
+      post: "/echooddnames"
+      body: "*"
+    };
+  }
   rpc ErrorRPC (Empty) returns (Empty) {
     option (google.api.http) = {
       get: "/error"
@@ -82,4 +89,10 @@ message MetaRequest{
 
 message MetaResponse {
   string V = 1;
+}
+
+message OddFieldNames {
+  int64 snake_case = 1;
+  int64 camelCase = 2;
+  int64 __why__so__many__underscores = 3;
 }

--- a/gengokit/httptransport/templates.go
+++ b/gengokit/httptransport/templates.go
@@ -84,13 +84,14 @@ var ClientEncodeTemplate = `
 
 		// Set the body parameters
 		var buf bytes.Buffer
-		toRet := map[string]interface{}{
+		toRet := request.(*pb.{{GoName $binding.Parent.RequestType}})
 		{{- range $field := $binding.Fields -}}
 			{{if eq $field.Location "body"}}
-				"{{$field.CamelName}}" : req.{{$field.CamelName}},
+				{{/* Only set the fields which should be in the body, so all
+				others will be omitted due to emptiness */}}
+				toRet.{{$field.CamelName}} = req.{{$field.CamelName}}
 			{{end}}
-		{{- end -}}
-		}
+		{{- end }}
 		if err := json.NewEncoder(&buf).Encode(toRet); err != nil {
 			return errors.Wrapf(err, "couldn't encode body as json %v", toRet)
 		}

--- a/gengokit/httptransport/templates_test.go
+++ b/gengokit/httptransport/templates_test.go
@@ -89,7 +89,7 @@ func EncodeHTTPSumZeroRequest(_ context.Context, r *http.Request, request interf
 
 	// Set the body parameters
 	var buf bytes.Buffer
-	toRet := map[string]interface{}{}
+	toRet := request.(*pb.SumRequest)
 	if err := json.NewEncoder(&buf).Encode(toRet); err != nil {
 		return errors.Wrapf(err, "couldn't encode body as json %v", toRet)
 	}


### PR DESCRIPTION
Within the client encoder, body parameters were being encoded incorrectly using the camelCased version of their go-name, instead of their original protobuf name.

This PR modifies the encoding of client parameters to use the built in protobuf structs encoded to json instead of a map of strings encoded to json, as the structs contain the correct struct tags to do this automatically. Additionally, it adds tests for catching this issue.

Big thanks to @siim- for pointing out this bug!