### PR TITLE
Fix #142: Panic when protobuf enum contains comments

### DIFF
--- a/cmd/protoc-gen-truss-protocast/main.go
+++ b/cmd/protoc-gen-truss-protocast/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	//"path"
 
 	"github.com/golang/protobuf/proto"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"

--- a/deftree/associate_comments.go
+++ b/deftree/associate_comments.go
@@ -85,8 +85,8 @@ func getCollectionIndex(node reflect.Value, index int) reflect.Value {
 // Converts a SourceLocation path into a "NamePath", an array of names of
 // objects, each nested within the last. Does this by walking backward through
 // the integer path in increments of two integers. The integer path almost
-// always follows a pattern of the first refering to a number in a field, and
-// the second refering to an index-th entry in the array that that field
+// always follows a pattern of the first referring to a number in a field, and
+// the second referring to an index-th entry in the array that that field
 // represents. buildNamePath walks the integer path, finding the names of these
 // entries and adding those names to the end of "NamePath". The returned slice
 // of strings thus represents the names of objects and their implicit parents,
@@ -94,7 +94,7 @@ func getCollectionIndex(node reflect.Value, index int) reflect.Value {
 // path.
 //
 // For example, there may be SourceLocation with a comment "spam eggs" and a
-// path like [ 4 2 6 0 ]. To find the actual unit of code refered to by this
+// path like [ 4 2 6 0 ]. To find the actual unit of code referred to by this
 // SourceLocation we must walk its path. Walking the path goes like so:
 //
 //     From the root file, go to the 4th field
@@ -131,9 +131,9 @@ func getCollectionIndex(node reflect.Value, index int) reflect.Value {
 // This idea that there are just simple objects or nodes that contain child
 // objects with some name is exactly how a Deftree is constructed and
 // navigated. Every node within the Deftree implements the "Describable"
-// interface, garunteeing that it has a Name, a Description (comments about the
-// node), and a GetByName method which allows you to query that node for any
-// child nodes with the name you specify.
+// interface, guaranteeing that it has a Name, a Description (comments about
+// the node), and a GetByName method which allows you to query that node for
+// any child nodes with the name you specify.
 func buildNamePath(path []int32, node reflect.Value) ([]string, error) {
 	log.WithFields(log.Fields{
 		"path": path,
@@ -226,6 +226,8 @@ func scrubComments(comment string) string {
 	return comment
 }
 
+// AssociateComments walks the provided CodeGeneratorRequest finding comments
+// and then copying them into their corresponding location within the deftree.
 func AssociateComments(dt Deftree, req *plugin.CodeGeneratorRequest) {
 	for _, file := range req.GetProtoFile() {
 		// Skip comments for files outside the main one being considered

--- a/deftree/associate_comments_test.go
+++ b/deftree/associate_comments_test.go
@@ -1,0 +1,48 @@
+package deftree
+
+import (
+	"testing"
+)
+
+// Test to ensure that placing comments within an Enum functions correctly.
+func TestCommentedEnum(t *testing.T) {
+	// Create our request, then assemble a basic deftree
+	defStr := `
+		syntax = "proto3";
+		package general;
+		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+
+		enum FooBarBaz {
+			// This is my comment, this is my note
+		   FOO = /* is this even valid */ 0;
+		   BAR = 1; // are we allowed
+		   BAZ = 2;
+		}
+		message SumRequest {
+			FooBarBaz a = 1;
+			int64 b = 2;
+		}
+
+		service SumSvc {
+			rpc Sum(SumRequest) returns (SumRequest) {
+				option (google.api.http) = {
+					get: "/sum/{a}"
+				};
+			}
+		}
+	`
+	dt, err := NewFromString(defStr, gopath)
+	md := dt.(*MicroserviceDefinition)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if md == nil {
+		t.Fatalf("The returned Deftree is nil")
+	}
+	got := md.Files[0].Enums[0].Values[0].Description
+	want := "This is my comment, this is my note"
+	if got != want {
+		t.Fatalf("Comment found in Enum is not expected; got = %q, want = %q", got, want)
+	}
+}

--- a/deftree/build_deftree.go
+++ b/deftree/build_deftree.go
@@ -33,18 +33,6 @@ func initGenGo(req *plugin.CodeGeneratorRequest) {
 	gengo.GenerateAllFiles()
 }
 
-func init() {
-	// Output to stderr instead of stdout, could also be a file.
-	log.SetOutput(os.Stderr)
-	// Force colors in logs to be on
-	log.SetFormatter(&log.TextFormatter{
-		ForceColors: true,
-	})
-
-	// Only log the warning severity or above.
-	log.SetLevel(log.InfoLevel)
-}
-
 // New accepts a Protobuf plugin.CodeGeneratorRequest and the contents of the
 // file containing the service declaration and returns a Deftree struct
 func New(req *plugin.CodeGeneratorRequest, serviceFile io.Reader) (Deftree, error) {
@@ -92,6 +80,8 @@ func New(req *plugin.CodeGeneratorRequest, serviceFile io.Reader) (Deftree, erro
 	return &dt, nil
 }
 
+// NewFromString creates a Deftree from a string of a valid protobuf
+// definition. A very useful function within tests.
 func NewFromString(def string, gopath []string) (Deftree, error) {
 	const defFileName = "definition.proto"
 

--- a/deftree/deftree.go
+++ b/deftree/deftree.go
@@ -294,7 +294,7 @@ func (self *MessageField) SetDescription(d string) {
 	self.Description = scrubComments(d)
 }
 
-func (self *MessageField) GetByName(s string) Describable {
+func (_ *MessageField) GetByName(s string) Describable {
 	return nil
 }
 
@@ -313,30 +313,39 @@ type ProtoEnum struct {
 	Values      []*EnumValue
 }
 
-func (self *ProtoEnum) GetName() string {
-	return self.Name
+func (pe *ProtoEnum) GetName() string {
+	return pe.Name
 }
 
-func (self *ProtoEnum) SetName(s string) {
-	self.Name = s
+func (pe *ProtoEnum) SetName(s string) {
+	pe.Name = s
 }
 
-func (self *ProtoEnum) GetDescription() string {
-	return self.Description
+func (pe *ProtoEnum) GetDescription() string {
+	return pe.Description
 }
 
-func (self *ProtoEnum) SetDescription(d string) {
+func (pe *ProtoEnum) SetDescription(d string) {
 	// When setting a description, clean it up
-	self.Description = scrubComments(d)
+	pe.Description = scrubComments(d)
 }
 
-func (self *ProtoEnum) Describe(depth int) string {
-	rv := genericDescribe(self, depth)
-	for idx, val := range self.Values {
+func (pe *ProtoEnum) Describe(depth int) string {
+	rv := genericDescribe(pe, depth)
+	for idx, val := range pe.Values {
 		rv += prindent(depth, "Value %v:\n", idx)
 		rv += val.Describe(depth + 1)
 	}
 	return rv
+}
+
+func (pe *ProtoEnum) GetByName(name string) Describable {
+	for _, ev := range pe.Values {
+		if ev.Name == name {
+			return ev
+		}
+	}
+	return nil
 }
 
 type EnumValue struct {
@@ -369,6 +378,10 @@ func (self *EnumValue) Describe(depth int) string {
 	return rv
 }
 
+func (_ *EnumValue) GetByName(s string) Describable {
+	return nil
+}
+
 type FieldType struct {
 	Describable
 	Name        string
@@ -397,7 +410,7 @@ func (self *FieldType) Describe(depth int) string {
 	return genericDescribe(self, depth)
 }
 
-func (self *FieldType) GetByName(s string) Describable {
+func (_ *FieldType) GetByName(s string) Describable {
 	return nil
 }
 
@@ -561,7 +574,7 @@ func (self *BindingField) SetDescription(d string) {
 	self.Description = scrubComments(d)
 }
 
-func (self *BindingField) GetByName(s string) Describable {
+func (_ *BindingField) GetByName(s string) Describable {
 	return nil
 }
 
@@ -602,7 +615,7 @@ func (self *HttpParameter) SetDescription(d string) {
 	self.Description = scrubComments(d)
 }
 
-func (self *HttpParameter) GetByName(s string) Describable {
+func (_ *HttpParameter) GetByName(s string) Describable {
 	return nil
 }
 

--- a/gendoc/generate_markdown.go
+++ b/gendoc/generate_markdown.go
@@ -74,11 +74,12 @@ func defaultDescribeMarkdown(d deftree.Describable, depth int) string {
 }
 
 func MdMicroserviceDefinition(m *deftree.MicroserviceDefinition, depth int) string {
-	rv := doc_css
-	rv += defaultDescribeMarkdown(m, depth)
+	rv := defaultDescribeMarkdown(m, depth)
 	for _, file := range m.Files {
 		rv += MdFile(file, depth+1)
 	}
+
+	rv += doc_css
 	return rv
 }
 


### PR DESCRIPTION
Implements a fix for issue #142 where a placing comments within an Enum in a Protobuf file caused `deftree` to panic.

The bug was that the `ProtoEnum` struct declares itself as implementing the `Describable` interface, but it actually did not; it didn't implement the `GetByName` method, thus the panic when something tried to call that method on that struct causing a nil pointer dereference.

Additionally, this adds a unit test to ensure that comments within enums don't cause panics and that the correct values are parsed.

--------

Also, this sneaks in small changes like spelling fixes in comments, as well as moving the css in generated documentation to the bottom of the document, making generated markdown documentation look better on github.