### PR TITLE
Fix #152: Migrate internals to ServiceName instead of PackageName

### DIFF
--- a/cmd/_integration-tests/transport/handlers/server/server_handler.go
+++ b/cmd/_integration-tests/transport/handlers/server/server_handler.go
@@ -13,13 +13,13 @@ import (
 
 // NewService returns a naïve, stateless implementation of Service.
 func NewService() pb.TransportPermutationsServer {
-	return transportService{}
+	return transportpermutationsService{}
 }
 
-type transportService struct{}
+type transportpermutationsService struct{}
 
 // GetWithQuery implements Service.
-func (s transportService) GetWithQuery(ctx context.Context, in *pb.GetWithQueryRequest) (*pb.GetWithQueryResponse, error) {
+func (s transportpermutationsService) GetWithQuery(ctx context.Context, in *pb.GetWithQueryRequest) (*pb.GetWithQueryResponse, error) {
 	response := pb.GetWithQueryResponse{
 		V: in.A + in.B,
 	}
@@ -28,7 +28,7 @@ func (s transportService) GetWithQuery(ctx context.Context, in *pb.GetWithQueryR
 }
 
 // GetWithRepeatedQuery implements Service.
-func (s transportService) GetWithRepeatedQuery(ctx context.Context, in *pb.GetWithRepeatedQueryRequest) (*pb.GetWithRepeatedQueryResponse, error) {
+func (s transportpermutationsService) GetWithRepeatedQuery(ctx context.Context, in *pb.GetWithRepeatedQueryRequest) (*pb.GetWithRepeatedQueryResponse, error) {
 	var out int64
 
 	for _, v := range in.A {
@@ -43,7 +43,7 @@ func (s transportService) GetWithRepeatedQuery(ctx context.Context, in *pb.GetWi
 }
 
 // PostWithNestedMessageBody implements Service.
-func (s transportService) PostWithNestedMessageBody(ctx context.Context, in *pb.PostWithNestedMessageBodyRequest) (*pb.PostWithNestedMessageBodyResponse, error) {
+func (s transportpermutationsService) PostWithNestedMessageBody(ctx context.Context, in *pb.PostWithNestedMessageBodyRequest) (*pb.PostWithNestedMessageBodyResponse, error) {
 	response := pb.PostWithNestedMessageBodyResponse{
 		V: in.NM.A + in.NM.B,
 	}
@@ -51,7 +51,7 @@ func (s transportService) PostWithNestedMessageBody(ctx context.Context, in *pb.
 }
 
 // CtxToCtx implements Service.
-func (s transportService) CtxToCtx(ctx context.Context, in *pb.MetaRequest) (*pb.MetaResponse, error) {
+func (s transportpermutationsService) CtxToCtx(ctx context.Context, in *pb.MetaRequest) (*pb.MetaResponse, error) {
 	var resp pb.MetaResponse
 	val := ctx.Value(in.Key)
 
@@ -67,7 +67,7 @@ func (s transportService) CtxToCtx(ctx context.Context, in *pb.MetaRequest) (*pb
 }
 
 // GetWithCapsPath implements Service.
-func (s transportService) GetWithCapsPath(ctx context.Context, in *pb.GetWithQueryRequest) (*pb.GetWithQueryResponse, error) {
+func (s transportpermutationsService) GetWithCapsPath(ctx context.Context, in *pb.GetWithQueryRequest) (*pb.GetWithQueryResponse, error) {
 	response := pb.GetWithQueryResponse{
 		V: in.A + in.B,
 	}
@@ -76,7 +76,7 @@ func (s transportService) GetWithCapsPath(ctx context.Context, in *pb.GetWithQue
 }
 
 // GetWithPathParams implements Service.
-func (s transportService) GetWithPathParams(ctx context.Context, in *pb.GetWithQueryRequest) (*pb.GetWithQueryResponse, error) {
+func (s transportpermutationsService) GetWithPathParams(ctx context.Context, in *pb.GetWithQueryRequest) (*pb.GetWithQueryResponse, error) {
 	response := pb.GetWithQueryResponse{
 		V: in.A + in.B,
 	}
@@ -84,13 +84,13 @@ func (s transportService) GetWithPathParams(ctx context.Context, in *pb.GetWithQ
 }
 
 // EchoOddNames implements Service.
-func (s transportService) EchoOddNames(ctx context.Context, in *pb.OddFieldNames) (*pb.OddFieldNames, error) {
+func (s transportpermutationsService) EchoOddNames(ctx context.Context, in *pb.OddFieldNames) (*pb.OddFieldNames, error) {
 	return in, nil
 }
 
 var testError error = errors.New("This error should be json over http transport")
 
 // ErrorRPC implements Service.
-func (s transportService) ErrorRPC(ctx context.Context, in *pb.Empty) (*pb.Empty, error) {
+func (s transportpermutationsService) ErrorRPC(ctx context.Context, in *pb.Empty) (*pb.Empty, error) {
 	return nil, testError
 }

--- a/gengokit/clientarggen/client_argument_generator.go
+++ b/gengokit/clientarggen/client_argument_generator.go
@@ -313,7 +313,7 @@ func applyTemplate(name string, tmpl string, executor interface{}, fncs template
 }
 
 // lowCamelName returns a CamelCased string, but with the first letter
-// lowercased. "package_name" becomes "packageName".
+// lowercased. "example_name" becomes "exampleName".
 func lowCamelName(s string) string {
 	s = gogen.CamelCase(s)
 	new := []rune(s)

--- a/gengokit/generator/gen.go
+++ b/gengokit/generator/gen.go
@@ -58,11 +58,11 @@ func generateResponseFile(templFP string, data *gengokit.Data, prevFile io.Reade
 	var err error
 
 	// Get the actual path to the file rather than the template file path
-	actualFP := templatePathToActual(templFP, data.PackageName)
+	actualFP := templatePathToActual(templFP, data.Service.Name)
 
 	switch templFP {
 	case handler.ServerHandlerPath:
-		h, err := handler.New(data.Service, prevFile, data.PackageName)
+		h, err := handler.New(data.Service, prevFile)
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot parse previous handler: %q", actualFP)
 		}
@@ -105,13 +105,13 @@ func generateResponseFile(templFP string, data *gengokit.Data, prevFile io.Reade
 	return bytes.NewReader(formattedCode), nil
 }
 
-// templatePathToActual accepts a templateFilePath and the packageName of the
+// templatePathToActual accepts a templateFilePath and the svcName of the
 // service and returns what the relative file path of what should be written to
 // disk
-func templatePathToActual(templFilePath, packageName string) string {
-	// Switch "NAME" in path with packageName.
-	// i.e. for packageName = addsvc; /NAME-service/NAME-server -> /addsvc-service/addsvc-server
-	actual := strings.Replace(templFilePath, "NAME", packageName, -1)
+func templatePathToActual(templFilePath, svcName string) string {
+	// Switch "NAME" in path with svcName.
+	// i.e. for svcName = addsvc; /NAME-service/NAME-server -> /addsvc-service/addsvc-server
+	actual := strings.Replace(templFilePath, "NAME", svcName, -1)
 
 	actual = strings.TrimSuffix(actual, "template")
 

--- a/gengokit/handler/templates.go
+++ b/gengokit/handler/templates.go
@@ -4,7 +4,7 @@ const serverMethsTempl = `
 {{ with $te := .}}
 		{{range $i := .Methods}}
 		// {{.Name}} implements Service.
-		func (s {{$te.PackageName}}Service) {{.Name}}(ctx context.Context, in *pb.{{GoName .RequestType.Name}}) (*pb.{{GoName .ResponseType.Name}}, error){
+		func (s {{ToLower $te.ServiceName}}Service) {{.Name}}(ctx context.Context, in *pb.{{GoName .RequestType.Name}}) (*pb.{{GoName .ResponseType.Name}}, error){
 			var resp pb.{{GoName .ResponseType.Name}}
 			resp = pb.{{GoName .ResponseType.Name}}{
 				{{range $j := $i.ResponseType.Message.Fields -}}
@@ -12,7 +12,7 @@ const serverMethsTempl = `
 				{{end -}}
 			}
 			return &resp, nil
-		} 
+		}
 		{{end}}
 {{- end}}
 `
@@ -28,19 +28,19 @@ import (
 
 // NewService returns a naïve, stateless implementation of Service.
 func NewService() pb.{{GoName .Service.Name}}Server {
-	return {{.PackageName}}Service{}
+	return {{ToLower .Service.Name}}Service{}
 }
 
-type {{.PackageName}}Service struct{}
+type {{ToLower .Service.Name}}Service struct{}
 
 {{with $te := . }}
 	{{range $i := $te.Service.Methods}}
 		// {{$i.Name}} implements Service.
-		func (s {{$te.PackageName}}Service) {{$i.Name}}(ctx context.Context, in *pb.{{GoName $i.RequestType.Name}}) (*pb.{{GoName $i.ResponseType.Name}}, error){
+		func (s {{ToLower $te.Service.Name}}Service) {{$i.Name}}(ctx context.Context, in *pb.{{GoName $i.RequestType.Name}}) (*pb.{{GoName $i.ResponseType.Name}}, error){
 			var resp pb.{{GoName $i.ResponseType.Name}}
 			resp = pb.{{GoName $i.ResponseType.Name}}{
 				{{range $j := $i.ResponseType.Message.Fields -}}
-					// {{GoName $j.Name}}: 
+					// {{GoName $j.Name}}:
 				{{end -}}
 			}
 			return &resp, nil

--- a/gengokit/httptransport/httptransport.go
+++ b/gengokit/httptransport/httptransport.go
@@ -359,7 +359,7 @@ func EnglishNumber(i int) string {
 }
 
 // LowCamelName returns a CamelCased string, but with the first letter
-// lowercased. "package_name" becomes "packageName".
+// lowercased. "example_name" becomes "exampleName".
 func LowCamelName(s string) string {
 	s = gogen.CamelCase(s)
 	new := []rune(s)

--- a/gengokit/httptransport/types.go
+++ b/gengokit/httptransport/types.go
@@ -40,7 +40,7 @@ type Field struct {
 	// Removes underscores, adds camelcase; "client_id" becomes "ClientId".
 	CamelName string
 	// The name of this field, but run through the camelcase function and with
-	// the first letter lowercased. "package_name" becomes "packageName".
+	// the first letter lowercased. "example_name" becomes "exampleName".
 	// LowCamelName is how the names of fields should appear when marshaled to
 	// JSON, according to the gRPC language guide.
 	LowCamelName string


### PR DESCRIPTION
This replaces all un-necessary references to `PackageName` with `ServiceName`, and modifies tests to reflect this change. Additionally, it has some code quality changes, e.g. fixing trailing whitespace.