### PR TITLE
Use PBFieldName (json tag name) as fieldname in query string

### DIFF
--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -323,9 +323,11 @@ func TestErrorRPCReturnsJSONError(t *testing.T) {
 // and expects must be pointers to structs.
 func testHTTP(
 	t *testing.T,
-	resp, expects interface{},
+	resp,
+	expects interface{},
 	bodyBytes []byte,
-	method, routeFormat string,
+	method,
+	routeFormat string,
 	routeFields ...interface{}) {
 	respBytes, err := httpRequestBuilder{
 		method: method,

--- a/gengokit/httptransport/httptransport.go
+++ b/gengokit/httptransport/httptransport.go
@@ -84,6 +84,7 @@ func NewBinding(i int, meth *svcdef.ServiceMethod) *Binding {
 		field := param.Field
 		newField := Field{
 			Name:         field.Name,
+			PBFieldName:  field.PBFieldName,
 			CamelName:    gogen.CamelCase(field.Name),
 			LowCamelName: LowCamelName(field.Name),
 			Location:     param.Location,
@@ -207,7 +208,7 @@ func (b *Binding) PathSections() []string {
 // of a query parameter into it's correct field on the request struct.
 func (f *Field) GenQueryUnmarshaler() (string, error) {
 	genericLogic := `
-{{.LocalName}}Str := {{.Location}}Params["{{.Name}}"]
+{{.LocalName}}Str := {{.Location}}Params["{{.PBFieldName}}"]
 {{.ConvertFunc}}
 // TODO: Better error handling
 if err != nil {

--- a/gengokit/httptransport/httptransport_test.go
+++ b/gengokit/httptransport/httptransport_test.go
@@ -60,6 +60,7 @@ func TestNewMethod(t *testing.T) {
 		Fields: []*Field{
 			&Field{
 				Name:           "A",
+				PBFieldName:    "a",
 				CamelName:      "A",
 				LowCamelName:   "a",
 				LocalName:      "ASum",
@@ -71,6 +72,7 @@ func TestNewMethod(t *testing.T) {
 			},
 			&Field{
 				Name:           "B",
+				PBFieldName:    "b",
 				CamelName:      "B",
 				LowCamelName:   "b",
 				LocalName:      "BSum",

--- a/gengokit/httptransport/templates_test.go
+++ b/gengokit/httptransport/templates_test.go
@@ -116,6 +116,7 @@ func TestGenServerDecode(t *testing.T) {
 		Fields: []*Field{
 			&Field{
 				Name:           "a",
+				PBFieldName:    "a",
 				CamelName:      "A",
 				LowCamelName:   "a",
 				LocalName:      "ASum",
@@ -127,6 +128,7 @@ func TestGenServerDecode(t *testing.T) {
 			},
 			&Field{
 				Name:           "b",
+				PBFieldName:    "b",
 				CamelName:      "B",
 				LowCamelName:   "b",
 				LocalName:      "BSum",

--- a/gengokit/httptransport/types.go
+++ b/gengokit/httptransport/types.go
@@ -36,6 +36,9 @@ type Binding struct {
 // useful for templating http transport.
 type Field struct {
 	Name string
+	// PBFieldName 'snake_case' in `protobuf:"varint,1,opt,name=snake_case,json=snakeCase" json:"snake_case,omitempty"`
+	// Where Name is 'SnakeCase'
+	PBFieldName string
 	// The name of this field, but passed through the CamelCase function.
 	// Removes underscores, adds camelcase; "client_id" becomes "ClientId".
 	CamelName string

--- a/svcdef/newfromstring_test.go
+++ b/svcdef/newfromstring_test.go
@@ -58,7 +58,8 @@ func TestMessages(t *testing.T) {
 			Name: "SumRequest",
 			Fields: []*Field{
 				&Field{
-					Name: "A",
+					Name:        "A",
+					PBFieldName: "a",
 					Type: &FieldType{
 						Name:      "int64",
 						Enum:      nil,
@@ -69,7 +70,8 @@ func TestMessages(t *testing.T) {
 					},
 				},
 				&Field{
-					Name: "B",
+					Name:        "B",
+					PBFieldName: "b",
 					Type: &FieldType{
 						Name:      "int64",
 						Enum:      nil,
@@ -85,7 +87,8 @@ func TestMessages(t *testing.T) {
 			Name: "SumReply",
 			Fields: []*Field{
 				&Field{
-					Name: "V",
+					Name:        "V",
+					PBFieldName: "v",
 					Type: &FieldType{
 						Name:      "int64",
 						Enum:      nil,
@@ -96,7 +99,8 @@ func TestMessages(t *testing.T) {
 					},
 				},
 				&Field{
-					Name: "Err",
+					Name:        "Err",
+					PBFieldName: "err",
 					Type: &FieldType{
 						Name:      "string",
 						Enum:      nil,
@@ -126,7 +130,8 @@ func TestHTTPBinding(t *testing.T) {
 				&HTTPParameter{
 					Location: "path",
 					Field: &Field{
-						Name: "A",
+						Name:        "A",
+						PBFieldName: "a",
 						Type: &FieldType{
 							Name: "int64",
 						},
@@ -135,7 +140,8 @@ func TestHTTPBinding(t *testing.T) {
 				&HTTPParameter{
 					Location: "query",
 					Field: &Field{
-						Name: "B",
+						Name:        "B",
+						PBFieldName: "b",
 						Type: &FieldType{
 							Name: "int64",
 						},


### PR DESCRIPTION
Closes #126 

When using the exposed HTTP API of a Truss generated web service the
query parameter names were required to be in PascalCase. This made sense
thinking about the underlying Go data structure, but not when working
with HTTP / QueryParams. Likewise its more consistent if
instead the snake cased names are used as they will match the json
fields that are accepted.