### PR TITLE
Remove automatic server-side prints

### DIFF
--- a/gengokit/httptransport/httptransport.go
+++ b/gengokit/httptransport/httptransport.go
@@ -219,9 +219,7 @@ if {{.LocalName}}StrArr, ok := {{.Location}}Params["{{.QueryParamName}}"]; ok {
 {{.ConvertFunc}}{{if .ConvertFuncNeedsErrorCheck}}
 // TODO: Better error handling
 if err != nil {
-	fmt.Printf("Error while extracting {{.LocalName}} from {{.Location}}: %v\n", err)
-	fmt.Printf("{{.Location}}Params: %v\n", {{.Location}}Params)
-	return nil, err
+	return nil, errors.Wrap(err, fmt.Sprintf("Error while extracting {{.LocalName}} from {{.Location}}, {{.Location}}Params: %v", {{.Location}}Params))
 }{{end}}
 req.{{.CamelName}} = {{.TypeConversion}}
 `

--- a/gengokit/httptransport/templates_test.go
+++ b/gengokit/httptransport/templates_test.go
@@ -173,7 +173,6 @@ func DecodeHTTPSumZeroRequest(_ context.Context, r *http.Request) (interface{}, 
 	pathParams, err := PathParams(r.URL.Path, "/sum/{a}")
 	_ = pathParams
 	if err != nil {
-		fmt.Printf("Error while reading path params: %v\n", err)
 		return nil, errors.Wrap(err, "couldn't unmarshal path parameters")
 	}
 
@@ -184,9 +183,7 @@ func DecodeHTTPSumZeroRequest(_ context.Context, r *http.Request) (interface{}, 
 	ASum, err := strconv.ParseInt(ASumStr, 10, 64)
 	// TODO: Better error handling
 	if err != nil {
-		fmt.Printf("Error while extracting ASum from path: %v\n", err)
-		fmt.Printf("pathParams: %v\n", pathParams)
-		return nil, err
+		return nil, errors.Wrap(err, fmt.Sprintf("Error while extracting ASum from path, pathParams: %v", pathParams))
 	}
 	req.A = ASum
 
@@ -195,9 +192,7 @@ func DecodeHTTPSumZeroRequest(_ context.Context, r *http.Request) (interface{}, 
 		BSum, err := strconv.ParseInt(BSumStr, 10, 64)
 		// TODO: Better error handling
 		if err != nil {
-			fmt.Printf("Error while extracting BSum from query: %v\n", err)
-			fmt.Printf("queryParams: %v\n", queryParams)
-			return nil, err
+			return nil, errors.Wrap(err, fmt.Sprintf("Error while extracting BSum from query, queryParams: %v", queryParams))
 		}
 		req.B = BSum
 	}


### PR DESCRIPTION
Remove print statements which are automatically run by the server, so errors and such will *not* print to the stdout of the server, instead they'll be included in the response. 