### PR TITLE
Fix for RPC camelcase binding

### DIFF
--- a/cmd/_integration-tests/transport/handlers/handlers.go
+++ b/cmd/_integration-tests/transport/handlers/handlers.go
@@ -94,3 +94,8 @@ var testError error = errors.New("This error should be json over http transport"
 func (s transportpermutationsService) ErrorRPC(ctx context.Context, in *pb.Empty) (*pb.Empty, error) {
 	return nil, testError
 }
+
+// X2AOddRPCName implements Service.
+func (s transportpermutationsService) X2AOddRPCName(ctx context.Context, in *pb.Empty) (*pb.Empty, error) {
+	return in, nil
+}

--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -311,6 +311,29 @@ func TestErrorRPCReturnsJSONError(t *testing.T) {
 	}
 }
 
+// Certain RPC's with strange names (names which change when passed through the
+// camelcase function) might break on HTTP encode/decode generation. Here we
+// call an RPC with an one of those odd names which returns an empty message.
+func TestStrangeRPCName(t *testing.T) {
+	var req pb.Empty
+
+	svchttp, err := httpclient.New(httpAddr)
+	if err != nil {
+		t.Fatalf("failed to create httpclient: %q", err)
+	}
+
+	resp, err := svchttp.X2AOddRPCName(context.Background(), &req)
+	if err != nil {
+		t.Fatalf("httpclient returned error: %q", err)
+	}
+
+	var want *pb.Empty
+	want = &pb.Empty{}
+	if resp != want {
+		t.Fatalf("Expect: %d, got %d", want, resp)
+	}
+}
+
 // Helpers
 
 // Generic way to test that making an HTTP request returns the expected data,

--- a/cmd/_integration-tests/transport/setup_test.go
+++ b/cmd/_integration-tests/transport/setup_test.go
@@ -37,6 +37,7 @@ func TestMain(m *testing.M) {
 	getWithPathParamsE := svc.MakeGetWithPathParamsEndpoint(service)
 	echoOddNamesE := svc.MakeEchoOddNamesEndpoint(service)
 	errorRPCE := svc.MakeErrorRPCEndpoint(service)
+	X2AOddRPCNameE := svc.MakeX2AOddRPCNameEndpoint(service)
 
 	endpoints := svc.Endpoints{
 		GetWithQueryEndpoint:              getWithQueryE,
@@ -47,6 +48,7 @@ func TestMain(m *testing.M) {
 		GetWithPathParamsEndpoint:         getWithPathParamsE,
 		EchoOddNamesEndpoint:              echoOddNamesE,
 		ErrorRPCEndpoint:                  errorRPCE,
+		X2AOddRPCNameEndpoint:             X2AOddRPCNameE,
 	}
 
 	ctx := context.Background()

--- a/cmd/_integration-tests/transport/transport-test.proto
+++ b/cmd/_integration-tests/transport/transport-test.proto
@@ -49,6 +49,12 @@ service TransportPermutations {
       get: "/error"
     };
   }
+  /* Odd RPC names need to still work */
+  rpc _2aOddRPCName (Empty) returns (Empty) {
+    option (google.api.http) = {
+      get: "/oddrpcname"
+    };
+  }
 }
 
 message Empty {}

--- a/svcdef/consolidate_http.go
+++ b/svcdef/consolidate_http.go
@@ -54,7 +54,7 @@ func consolidateHTTP(sd *Svcdef, protoFiles map[string]io.Reader) error {
 		}
 		err = assembleHTTPParams(sd.Service, protosvc)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "while assembling HTTP parameters")
 		}
 	}
 	return nil

--- a/svcdef/svcdef.go
+++ b/svcdef/svcdef.go
@@ -193,7 +193,7 @@ func New(goFiles map[string]io.Reader, protoFiles map[string]io.Reader) (*Svcdef
 		fset := token.NewFileSet()
 		fileAst, err := parser.ParseFile(fset, "", gofile, parser.ParseComments)
 		if err != nil {
-			return nil, errors.Wrapf(err, "couldn't parse go file %q to create Svcdef", path)
+			return nil, errors.Wrapf(err, "cannot parse go file %q to create Svcdef", path)
 		}
 		debugInfo := &DebugInfo{
 			Path: path,
@@ -203,7 +203,7 @@ func New(goFiles map[string]io.Reader, protoFiles map[string]io.Reader) (*Svcdef
 
 		typespecs, err := retrieveTypeSpecs(fileAst)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not retrive type specs")
+			return nil, errors.Wrap(err, "cannot retrive type specs")
 		}
 		for _, t := range typespecs {
 			switch typdf := t.Type.(type) {
@@ -267,7 +267,7 @@ func NewMessage(m *ast.TypeSpec) (*Message, error) {
 	for _, f := range strct.Fields.List {
 		nfield, err := NewField(f)
 		if err != nil {
-			return nil, errors.Wrapf(err, "couldn't create field %q while creating message %q", f.Names[0].Name, rv.Name)
+			return nil, errors.Wrapf(err, "cannot create field %q while creating message %q", f.Names[0].Name, rv.Name)
 		}
 		rv.Fields = append(rv.Fields, nfield)
 	}
@@ -324,7 +324,7 @@ func NewService(s *ast.TypeSpec, info *DebugInfo) (*Service, error) {
 	for _, m := range asvc.Methods.List {
 		nmeth, err := NewServiceMethod(m, info)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Couldn't create service method %q of service %q", m.Names[0].Name, rv.Name)
+			return nil, errors.Wrapf(err, "cannot create service method %q of service %q", m.Names[0].Name, rv.Name)
 		}
 		rv.Methods = append(rv.Methods, nmeth)
 	}
@@ -340,7 +340,7 @@ func NewServiceMethod(m *ast.Field, info *DebugInfo) (*ServiceMethod, error) {
 	}
 	ft, ok := m.Type.(*ast.FuncType)
 	if !ok {
-		return nil, NewLocationError("Provided *ast.Field.Type is not of type "+
+		return nil, NewLocationError("provided *ast.Field.Type is not of type "+
 			"*ast.FuncType; cannot proceed",
 			info.Path, info.Position(m.Pos()))
 	}
@@ -363,13 +363,13 @@ func NewServiceMethod(m *ast.Field, info *DebugInfo) (*ServiceMethod, error) {
 	makeFieldType := func(in *ast.Field) (*FieldType, error) {
 		star, ok := in.Type.(*ast.StarExpr)
 		if !ok {
-			return nil, NewLocationError("could not create FieldType, in.Type "+
+			return nil, NewLocationError("cannot create FieldType, in.Type "+
 				"is not *ast.StarExpr",
 				info.Path, info.Position(in.Pos()))
 		}
 		ident, ok := star.X.(*ast.Ident)
 		if !ok {
-			return nil, NewLocationError("could not create FieldType, "+
+			return nil, NewLocationError("cannot create FieldType, "+
 				"star.Type is not *ast.Ident",
 				info.Path, info.Position(star.Pos()))
 		}
@@ -382,11 +382,11 @@ func NewServiceMethod(m *ast.Field, info *DebugInfo) (*ServiceMethod, error) {
 	var err error
 	rv.RequestType, err = makeFieldType(rq)
 	if err != nil {
-		return nil, errors.Wrapf(err, "RequestType creation of service method %q failed", rv.Name)
+		return nil, errors.Wrapf(err, "requestType creation of service method %q failed", rv.Name)
 	}
 	rv.ResponseType, err = makeFieldType(rs)
 	if err != nil {
-		return nil, errors.Wrapf(err, "ResponseType creation of service method %q failed", rv.Name)
+		return nil, errors.Wrapf(err, "responseType creation of service method %q failed", rv.Name)
 	}
 
 	return rv, nil


### PR DESCRIPTION
Fixes a bug where RPC methods with names that changed when camelcased would fail to have HTTP transport generated, and all HTTP transport encode/decode functions thereafter would also fail to be generated.

This was because camelcased names where improperly handled within `svcdef.assembleHTTPParams`, and errors returned from that function wheren't being checked : (

But now that's fixed, and a test has been added!