### PR TITLE
Fix service not building if no http annoitations specified

### DIFF
--- a/cmd/_integration-tests/cli/cli_test.go
+++ b/cmd/_integration-tests/cli/cli_test.go
@@ -160,19 +160,29 @@ func TestMultipleFiles(t *testing.T) {
 	testEndToEnd("1-multifile", "getbasic", t)
 }
 
-// Disabled until repeated types are implemented for cliclient
 func TestRepeatedTypes(t *testing.T) {
 	testEndToEnd("2-repeated", "getrepeated", t)
 }
 
-// Disabled until nested types are implemented for cliclient
-func _TestNestedTypes(t *testing.T) {
+func TestNestedTypes(t *testing.T) {
 	testEndToEnd("3-nested", "getnested", t)
 }
 
 // Disabled until map types are implemented for cliclient
 func _TestMapTypes(t *testing.T) {
 	testEndToEnd("4-maps", "getmap", t)
+}
+
+func TestGRPCOnly(t *testing.T) {
+	path := filepath.Join(basePath, "5-grpconly")
+	err := createTrussService(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = buildTestService(filepath.Join(path, "test-service"))
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func testEndToEnd(defDir string, subcmd string, t *testing.T, trussOptions ...string) {

--- a/cmd/_integration-tests/cli/test-service-definitions/5-grpconly/grpconly.proto
+++ b/cmd/_integration-tests/cli/test-service-definitions/5-grpconly/grpconly.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+package grpconly;
+
+service TEST {
+  rpc GetBasic (BasicTypeRequest) returns (BasicTypeResponse) {}
+  rpc PostBasic (BasicTypeRequest) returns (BasicTypeRequest) {}
+}
+
+message BasicTypeRequest {
+  double A = 1;
+  float B = 2;
+  int32 C = 3;
+  int64 D = 4;
+  uint32 E = 5;
+  uint64 F = 6;
+  sint32 G = 7;
+  sint64 H = 8;
+  fixed32 I = 9;
+  fixed64 J = 10;
+  sfixed32 K = 11;
+  bool L = 12;
+  string M = 13;
+  bytes N = 14;
+}
+
+message BasicTypeResponse {
+  double A = 1;
+  float B = 2;
+  int32 C = 3;
+  int64 D = 4;
+  uint32 E = 5;
+  uint64 F = 6;
+  sint32 G = 7;
+  sint64 H = 8;
+  fixed32 I = 9;
+  fixed64 J = 10;
+  sfixed32 K = 11;
+  bool L = 12;
+  string M = 13;
+  bytes N = 14;
+}
+

--- a/gengokit/httptransport/templates/client.go
+++ b/gengokit/httptransport/templates/client.go
@@ -100,6 +100,8 @@ var (
 	_ = endpoint.Chain
 	_ = httptransport.NewClient
 	_ = fmt.Sprint
+	_ = bytes.Compare
+	_ = ioutil.NopCloser
 )
 
 // New returns a service backed by an HTTP server living at the remote

--- a/gengokit/httptransport/templates/server.go
+++ b/gengokit/httptransport/templates/server.go
@@ -149,6 +149,7 @@ var (
 	_ = ioutil.NopCloser
 	_ = pb.Register{{.Service.Name}}Server
 	_ = io.Copy
+	_ = errors.Wrap
 )
 
 // MakeHTTPHandler returns a handler that makes a set of endpoints available


### PR DESCRIPTION
- [X] Add test for gRPC only service; no http annotations in proto file.
- [X] Fix http server and client transport to build if no http annotations specified.