### PR TITLE
Fix: Update http client to only use one binding for transport

### DIFF
--- a/cmd/_integration-tests/cli/cli_test.go
+++ b/cmd/_integration-tests/cli/cli_test.go
@@ -185,6 +185,10 @@ func TestGRPCOnly(t *testing.T) {
 	}
 }
 
+func TestAdditionalBindings(t *testing.T) {
+	testEndToEnd("6-additional_bindings", "getadditional", t)
+}
+
 func testEndToEnd(defDir string, subcmd string, t *testing.T, trussOptions ...string) {
 	path := filepath.Join(basePath, defDir)
 	err := createTrussService(path)
@@ -230,7 +234,7 @@ func createTrussService(path string, trussFlags ...string) error {
 
 	// If truss fails, test error and skip communication
 	if err != nil {
-		return errors.Errorf("Truss generation FAILED - %v\nTruss Output:\n%v", path, trussOut)
+		return errors.Errorf("Truss generation FAILED - %v\nTruss Output:\n%v Error:\n%v", path, trussOut, err)
 	}
 
 	return nil

--- a/cmd/_integration-tests/cli/test-service-definitions/6-additional_bindings/additional_bindings.proto
+++ b/cmd/_integration-tests/cli/test-service-definitions/6-additional_bindings/additional_bindings.proto
@@ -1,0 +1,65 @@
+syntax = "proto3";
+
+package additional_bindings;
+
+import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+
+service TEST {
+  rpc GetAdditional (BasicTypeRequest) returns (BasicTypeResponse) {
+    option (google.api.http) = {
+      get: "/1"
+
+      additional_bindings {
+        get: "/1/1"
+      }
+    };
+  }
+
+
+  rpc PostAdditional (BasicTypeRequest) returns (BasicTypeRequest) {
+    option (google.api.http) = {
+      post: "/2"
+      body: "*"
+
+      additional_bindings {
+        post: "/2/2"
+        body: "*"
+      }
+    };
+  }
+}
+
+message BasicTypeRequest {
+  double A = 1;
+  float B = 2;
+  int32 C = 3;
+  int64 D = 4;
+  uint32 E = 5;
+  uint64 F = 6;
+  sint32 G = 7;
+  sint64 H = 8;
+  fixed32 I = 9;
+  fixed64 J = 10;
+  sfixed32 K = 11;
+  bool L = 12;
+  string M = 13;
+  bytes N = 14;
+}
+
+message BasicTypeResponse {
+  double A = 1;
+  float B = 2;
+  int32 C = 3;
+  int64 D = 4;
+  uint32 E = 5;
+  uint64 F = 6;
+  sint32 G = 7;
+  sint64 H = 8;
+  fixed32 I = 9;
+  fixed64 J = 10;
+  sfixed32 K = 11;
+  bool L = 12;
+  string M = 13;
+  bytes N = 14;
+}
+

--- a/gengokit/httptransport/templates/client.go
+++ b/gengokit/httptransport/templates/client.go
@@ -137,25 +137,29 @@ func New(instance string, options ...ClientOption) (pb.{{GoName .Service.Name}}S
 	{{- end}}
 
 	{{range $method := .HTTPHelper.Methods}}
-		{{range $binding := $method.Bindings}}
-			var {{$binding.Label}}Endpoint endpoint.Endpoint
-			{
-				{{$binding.Label}}Endpoint = httptransport.NewClient(
-					"{{$binding.Verb}}",
-					copyURL(u, "{{$binding.BasePath}}"),
-					EncodeHTTP{{$binding.Label}}Request,
-					DecodeHTTP{{$method.Name}}Response,
-					clientOptions...,
-				).Endpoint()
-			}
+		{{ if $method.Bindings -}}
+			{{ with $binding := index $method.Bindings 0 -}}
+				var {{$binding.Label}}Endpoint endpoint.Endpoint
+				{
+					{{$binding.Label}}Endpoint = httptransport.NewClient(
+						"{{$binding.Verb}}",
+						copyURL(u, "{{$binding.BasePath}}"),
+						EncodeHTTP{{$binding.Label}}Request,
+						DecodeHTTP{{$method.Name}}Response,
+						clientOptions...,
+					).Endpoint()
+				}
+			{{- end}}
 		{{- end}}
 	{{- end}}
 
 	return svc.Endpoints{
 	{{range $method := .HTTPHelper.Methods -}}
-		{{range $binding := $method.Bindings -}}
-			{{$method.Name}}Endpoint:    {{$binding.Label}}Endpoint,
-		{{end}}
+		{{ if $method.Bindings -}}
+			{{ with $binding := index $method.Bindings 0 -}}
+				{{$method.Name}}Endpoint:    {{$binding.Label}}Endpoint,
+			{{end}}
+		{{- end}}
 	{{- end}}
 	}, nil
 }


### PR DESCRIPTION
Using `additional_bindings` in a service definition caused the http client to not build.
- [X] Fix
- [X] Add a test for this case.