### PR TITLE
Disable HTML escaping in JSON encoder

### DIFF
--- a/gengokit/httptransport/templates/client.go
+++ b/gengokit/httptransport/templates/client.go
@@ -60,7 +60,9 @@ var ClientEncodeTemplate = `
 				toRet.{{$field.CamelName}} = req.{{$field.CamelName}}
 			{{end}}
 		{{- end }}
-		if err := json.NewEncoder(&buf).Encode(toRet); err != nil {
+		encoder := json.NewEncoder(&buf)
+		encoder.SetEscapeHTML(false)
+		if err := encoder.Encode(toRet); err != nil {
 			return errors.Wrapf(err, "couldn't encode body as json %v", toRet)
 		}
 		r.Body = ioutil.NopCloser(&buf)

--- a/gengokit/httptransport/templates/server.go
+++ b/gengokit/httptransport/templates/server.go
@@ -201,7 +201,9 @@ type errorWrapper struct {
 // EncodeHTTPGenericResponse is a transport/http.EncodeResponseFunc that encodes
 // the response as JSON to the response writer. Primarily useful in a server.
 func EncodeHTTPGenericResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
-	return json.NewEncoder(w).Encode(response)
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(response)
 }
 
 // Helper functions

--- a/gengokit/httptransport/templates_test.go
+++ b/gengokit/httptransport/templates_test.go
@@ -97,7 +97,9 @@ func EncodeHTTPSumZeroRequest(_ context.Context, r *http.Request, request interf
 	// Set the body parameters
 	var buf bytes.Buffer
 	toRet := request.(*pb.SumRequest)
-	if err := json.NewEncoder(&buf).Encode(toRet); err != nil {
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(toRet); err != nil {
 		return errors.Wrapf(err, "couldn't encode body as json %v", toRet)
 	}
 	r.Body = ioutil.NopCloser(&buf)


### PR DESCRIPTION
The Go standard JSON encoder will escape HTML characters that it encounters while encoding a JSON object. That's dumb, and it messes with responses from Truss, so this PR disables HTML escaping in generated JSON response encoders.

- [x] Disable HTML escaping in generated JSON response encoders
- [x] Modify tests to match change in generated code