### PR TITLE
Make error logging use more standard 'err' key

### DIFF
--- a/gengokit/httptransport/templates/server.go
+++ b/gengokit/httptransport/templates/server.go
@@ -278,7 +278,7 @@ func HTTPDecodeLogger(next httptransport.DecodeRequestFunc, logger log.Logger) h
 		logger.Log("method", r.Method, "url", r.URL.String())
 		rv, err := next(ctx, r)
 		if err != nil {
-			logger.Log("method", r.Method, "url", r.URL.String(), "Error", err)
+			logger.Log("method", r.Method, "url", r.URL.String(), "err", err)
 		}
 		return rv, err
 	}


### PR DESCRIPTION
Changes one line in the http decode logger to use the somewhat more standard "err" error key in logs.