### PR TITLE
Add default flag and protobuf file as output

### DIFF
--- a/cmd/truss/main.go
+++ b/cmd/truss/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/TuneLab/go-truss/truss"
 	"github.com/TuneLab/go-truss/truss/execprotoc"
+	"github.com/TuneLab/go-truss/truss/getstarted"
 	"github.com/TuneLab/go-truss/truss/parsesvcname"
 
 	"github.com/TuneLab/go-truss/deftree"
@@ -29,6 +30,7 @@ var (
 	svcPackageFlag = flag.String("svcout", "", "Go package path where the generated Go service will be written. Trailing slash will create a NAME-service directory")
 	verboseFlag    = flag.BoolP("verbose", "v", false, "Verbose output")
 	helpFlag       = flag.BoolP("help", "h", false, "Print usage")
+	getStartedFlag = flag.BoolP("getstarted", "", false, "Output a 'getstarted.proto' protobuf file in ./")
 )
 
 var binName = filepath.Base(os.Args[0])
@@ -77,15 +79,23 @@ func main() {
 		os.Exit(0)
 	}
 
+	log.SetLevel(log.InfoLevel)
+	if *verboseFlag {
+		log.SetLevel(log.DebugLevel)
+	}
+
+	if *getStartedFlag {
+		pkg := ""
+		if len(flag.Args()) > 0 {
+			pkg = flag.Args()[0]
+		}
+		os.Exit(getstarted.Do(pkg))
+	}
+
 	if len(flag.Args()) == 0 {
 		fmt.Fprintf(os.Stderr, "%s: missing .proto file(s)\n", binName)
 		flag.Usage()
 		os.Exit(1)
-	}
-
-	log.SetLevel(log.InfoLevel)
-	if *verboseFlag {
-		log.SetLevel(log.DebugLevel)
 	}
 
 	cfg, err := parseInput()

--- a/truss/getstarted/getstarted.go
+++ b/truss/getstarted/getstarted.go
@@ -1,0 +1,116 @@
+package getstarted
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"text/template"
+
+	log "github.com/Sirupsen/logrus"
+	gogen "github.com/golang/protobuf/protoc-gen-go/generator"
+	"github.com/pkg/errors"
+)
+
+type protoInfo struct {
+	alias string
+}
+
+func (p protoInfo) FileName() string {
+	return p.PackageName() + ".proto"
+}
+
+func (p protoInfo) PackageName() string {
+	a := p.alias
+	a = strings.Replace(a, "-", "", -1)
+	a = strings.Replace(a, "_", "", -1)
+	a = strings.Replace(a, " ", "", -1)
+
+	a = strings.ToLower(a)
+	return a
+}
+
+func (p protoInfo) ServiceName() string {
+	a := p.alias
+	a = strings.Replace(a, "-", "_", -1)
+	a = strings.Replace(a, " ", "_", -1)
+	return gogen.CamelCase(a)
+}
+
+// Do writes a default protobuf file to the current directory, in a file named
+// "default.proto". If the file exists, it prints a warning and returns a
+// non-zero exit code. The non-zero exit code is to enable using the return
+// from this function in os.Exit().
+func Do(pkg string) int {
+	const fallbackFName = "get_started"
+	if pkg == "" {
+		pkg = fallbackFName
+	}
+	pkg = removeDotProto(pkg)
+	pinfo := protoInfo{
+		alias: pkg,
+	}
+	// For convenience sake, render the help messages now. Saves us from doing
+	// nested error checks later, making the code a bit clearer.
+	nextStep, err := renderTemplate("nextStepMsg", nextStepMsg, pinfo)
+	if err != nil {
+		log.Error(err)
+		return 1
+	}
+	existingFile, err := renderTemplate("existingFileMsg", existingFileMsg, pinfo)
+	if err != nil {
+		log.Error(err)
+		return 1
+	}
+
+	if _, err := os.Stat(pinfo.FileName()); err == nil {
+		log.Error(string(existingFile))
+		return 1
+	}
+	f, err := os.Create(pinfo.FileName())
+	if err != nil {
+		log.Error(errors.Wrapf(err, "cannot create %q", pinfo.FileName()))
+		return 1
+	}
+
+	code, err := renderTemplate(pinfo.FileName(), starterProto, pinfo)
+	if err != nil {
+		log.Error(err)
+		return 1
+	}
+
+	_, err = f.Write(code)
+	if err != nil {
+		log.Error(errors.Wrapf(err, "cannot write default contents to %q", pinfo))
+		return 1
+	}
+	log.Info(string(nextStep))
+	return 0
+}
+
+// removeDotProto exists to preempt and warn a user who enters a name
+// containing `.proto`. It will warn the user of their incorrect input and will
+// demonstrate how their input can be corrected. Then, the program continues
+// using the corrected input it warned about.
+func removeDotProto(pkg string) string {
+	want := strings.Replace(pkg, ".proto", "", -1)
+	if strings.HasSuffix(pkg, ".proto") {
+		executor := struct{ Got, Want string }{pkg, want}
+		warn, err := renderTemplate("dotProtoInName", dotProtoInName, executor)
+		if err != nil {
+			log.Error(err)
+		}
+		log.Warn(string(warn))
+	}
+	return want
+}
+
+func renderTemplate(name string, tmpl string, executor interface{}) ([]byte, error) {
+	codeTemplate := template.Must(template.New(name).Parse(tmpl))
+
+	code := bytes.NewBuffer(nil)
+	err := codeTemplate.Execute(code, executor)
+	if err != nil {
+		return []byte{}, errors.Wrapf(err, "attempting to execute template %q", name)
+	}
+	return code.Bytes(), nil
+}

--- a/truss/getstarted/getstarted_test.go
+++ b/truss/getstarted/getstarted_test.go
@@ -1,0 +1,63 @@
+package getstarted
+
+import "testing"
+
+func TestProtoInfo_FileName(t *testing.T) {
+	var cases = []struct {
+		alias, want string
+	}{
+		{"FooBar", "foobar.proto"},
+		{"foo-bar", "foobar.proto"},
+		{"foo_bar", "foobar.proto"},
+		{"foo bar", "foobar.proto"},
+	}
+
+	for _, test := range cases {
+		p := protoInfo{
+			alias: test.alias,
+		}
+		if got, want := p.FileName(), test.want; got != want {
+			t.Errorf("Failed to generate correct filename for input %q; got %q, want %q", test.alias, got, want)
+		}
+	}
+}
+
+func TestProtoInfo_PackageName(t *testing.T) {
+	var cases = []struct {
+		alias, want string
+	}{
+		{"foobar", "foobar"},
+		{"foo-bar", "foobar"},
+		{"foo_bar", "foobar"},
+		{"foo bar", "foobar"},
+	}
+
+	for _, test := range cases {
+		p := protoInfo{
+			alias: test.alias,
+		}
+		if got, want := p.PackageName(), test.want; got != want {
+			t.Errorf("Failed to generate correct package name for input %q; got %q, want %q", test.alias, got, want)
+		}
+	}
+}
+
+func TestProtoInfo_ServiceName(t *testing.T) {
+	var cases = []struct {
+		alias, want string
+	}{
+		{"foobar", "Foobar"},
+		{"foo-bar", "FooBar"},
+		{"foo_bar", "FooBar"},
+		{"foo bar", "FooBar"},
+	}
+
+	for _, test := range cases {
+		p := protoInfo{
+			alias: test.alias,
+		}
+		if got, want := p.ServiceName(), test.want; got != want {
+			t.Errorf("Failed to generate correct service name for input %q; got %q, want %q", test.alias, got, want)
+		}
+	}
+}

--- a/truss/getstarted/template.go
+++ b/truss/getstarted/template.go
@@ -1,0 +1,57 @@
+package getstarted
+
+const starterProto = `
+syntax = "proto3";
+
+package {{.PackageName}};
+ 
+import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+
+service {{.ServiceName}} {
+  rpc Status(StatusRequest) returns (StatusResponse) {
+    option (google.api.http) = {
+      get: "/Status"
+    };
+  }
+}
+
+enum ServiceStatus {
+  FAIL = 0;
+  OK = 1;
+}
+
+message StatusRequest {
+  bool full = 1;
+}
+
+message StatusResponse {
+  ServiceStatus status = 1;
+}
+`
+
+const nextStepMsg = `A "starter" protobuf file named '{{.FileName}}' has been created in the
+current directory. You can generate a service based on this new protobuf file
+at any time using the following command:
+
+    truss {{.FileName}}
+
+If you want to generate a protofile with a different name, use the
+'--getstarted' option with the name of your choice after '--getstarted'. For
+example, to generate a 'foo.proto', use the following command:
+
+    truss --getstarted foo
+`
+const existingFileMsg = `There's already a "starter" protobuf file named '{{.FileName}}' in the current
+directory. If you'd like to generate a service based on this existing protobuf
+file, you should instead run the command:
+
+    truss {{.FileName}}`
+
+const dotProtoInName = `The name you provided has a suffix of '.proto' when it should not. Instead of
+'{{.Got}}', you should provide '{{.Want}}'. Here's an example of the correct
+command to enter next time:
+
+	truss --getstarted {{.Want}}
+
+For now this program is continuing as though you used '{{.Want}}'.
+`


### PR DESCRIPTION
This PR adds the `--default` flag to truss, which gives you a basic service-compatible protobuf file "out of the box". However, there's several items I want to bring to the attention of reviewers:

1. Do we want this feature to only output a `.proto` file, or should it also generate a service? If so, how are names for services in the generated proto file chosen? Where should the service be located?
2. Currently, the default proto file which is created has a single RPC, called `Status`, based on what we use within multiverse. Are there other RPC's to include in the default proto file?
3. The actual name of the package and service in this default file cannot be named `default`, as that's a reserved word in the protocol buffer language. To get this up fast, I just removed the vowels and used `Dflt`, but that's pretty gross. So, we may want to chose a different name, such as "example", "initial", or "sample". Feel free to suggest others.