### PR TITLE
Add --getstarted flag for creating a protobuf file

### DIFF
--- a/cmd/truss/main.go
+++ b/cmd/truss/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/TuneLab/go-truss/truss"
 	"github.com/TuneLab/go-truss/truss/execprotoc"
+	"github.com/TuneLab/go-truss/truss/getstarted"
 	"github.com/TuneLab/go-truss/truss/parsesvcname"
 
 	"github.com/TuneLab/go-truss/deftree"
@@ -29,6 +30,7 @@ var (
 	svcPackageFlag = flag.String("svcout", "", "Go package path where the generated Go service will be written. Trailing slash will create a NAME-service directory")
 	verboseFlag    = flag.BoolP("verbose", "v", false, "Verbose output")
 	helpFlag       = flag.BoolP("help", "h", false, "Print usage")
+	getStartedFlag = flag.BoolP("getstarted", "", false, "Output a 'getstarted.proto' protobuf file in ./")
 )
 
 var binName = filepath.Base(os.Args[0])
@@ -77,15 +79,23 @@ func main() {
 		os.Exit(0)
 	}
 
+	log.SetLevel(log.InfoLevel)
+	if *verboseFlag {
+		log.SetLevel(log.DebugLevel)
+	}
+
+	if *getStartedFlag {
+		pkg := ""
+		if len(flag.Args()) > 0 {
+			pkg = flag.Args()[0]
+		}
+		os.Exit(getstarted.Do(pkg))
+	}
+
 	if len(flag.Args()) == 0 {
 		fmt.Fprintf(os.Stderr, "%s: missing .proto file(s)\n", binName)
 		flag.Usage()
 		os.Exit(1)
-	}
-
-	log.SetLevel(log.InfoLevel)
-	if *verboseFlag {
-		log.SetLevel(log.DebugLevel)
 	}
 
 	cfg, err := parseInput()

--- a/truss/getstarted/getstarted.go
+++ b/truss/getstarted/getstarted.go
@@ -1,0 +1,121 @@
+package getstarted
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"text/template"
+
+	log "github.com/Sirupsen/logrus"
+	gogen "github.com/golang/protobuf/protoc-gen-go/generator"
+	"github.com/pkg/errors"
+)
+
+type protoInfo struct {
+	alias string
+}
+
+func (p protoInfo) FileName() string {
+	return p.PackageName() + ".proto"
+}
+
+func (p protoInfo) PackageName() string {
+	a := p.alias
+	a = strings.Replace(a, "-", "", -1)
+	a = strings.Replace(a, " ", "", -1)
+
+	a = strings.ToLower(a)
+	return a
+}
+
+func (p protoInfo) ServiceName() string {
+	a := p.alias
+	a = strings.Replace(a, "-", "_", -1)
+	a = strings.Replace(a, " ", "_", -1)
+	return gogen.CamelCase(a)
+}
+
+// Do writes a default protobuf file to the current directory, in a file named
+// based on the 'pkg' param, defaulting to "getstarted.proto" if pkg is empty.
+// If the file exists, Do prints a warning and returns a non-zero exit code.
+// The non-zero exit code is to enable using the return from this function in
+// os.Exit().
+func Do(pkg string) int {
+	const fallbackFName = "get_started"
+	if pkg == "" {
+		pkg = fallbackFName
+	}
+	pkg = removeDotProtoSuffix(pkg)
+	pinfo := protoInfo{
+		alias: pkg,
+	}
+	if _, err := os.Stat(pinfo.FileName()); err == nil {
+		existingFile, err := renderTemplate("existingFileMsg", existingFileMsg, pinfo)
+		if err != nil {
+			log.Error(err)
+			return 1
+		}
+		log.Error(string(existingFile))
+		return 1
+	}
+	f, err := os.Create(pinfo.FileName())
+	if err != nil {
+		log.Error(errors.Wrapf(err, "cannot create %q", pinfo.FileName()))
+		return 1
+	}
+
+	code, err := renderTemplate(pinfo.FileName(), starterProto, pinfo)
+	if err != nil {
+		log.Error(err)
+		return 1
+	}
+
+	_, err = f.Write(code)
+	if err != nil {
+		log.Error(errors.Wrapf(err, "cannot write default contents to %q", pinfo.FileName()))
+		return 1
+	}
+	nextStep, err := renderTemplate("nextStepMsg", nextStepMsg, pinfo)
+	if err != nil {
+		log.Error(err)
+		return 1
+	}
+	log.Info(string(nextStep))
+	return 0
+}
+
+// removeDotProtoSuffix exists to preempt and warn a user who enters a name
+// containing `.proto`. It will warn the user of their incorrect input and will
+// demonstrate how their input can be corrected. Then, the program continues
+// using the corrected input it warned about.
+func removeDotProtoSuffix(pkg string) string {
+	const dotProtoInName = `The name you provided has a suffix of '.proto' when it should not. Instead of
+'{{.Got}}', you should provide '{{.Want}}'. Here's an example of the correct
+command to enter next time:
+
+	truss --getstarted {{.Want}}
+
+For now this program is continuing as though you used '{{.Want}}'.
+`
+	want := strings.Replace(pkg, ".proto", "", -1)
+	if strings.HasSuffix(pkg, ".proto") {
+		executor := struct{ Got, Want string }{pkg, want}
+		warn, err := renderTemplate("dotProtoInName", dotProtoInName, executor)
+		if err != nil {
+			log.Error(err)
+		}
+		log.Warn(string(warn))
+	}
+	return want
+}
+
+func renderTemplate(name string, tmpl string, executor interface{}) ([]byte, error) {
+	codeTemplate := template.Must(template.New(name).Parse(tmpl))
+
+	code := bytes.NewBuffer(nil)
+	err := codeTemplate.Execute(code, executor)
+	if err != nil {
+		return nil, errors.Wrapf(err, "attempting to execute template %q", name)
+	}
+	return code.Bytes(), nil
+}

--- a/truss/getstarted/getstarted_test.go
+++ b/truss/getstarted/getstarted_test.go
@@ -1,0 +1,63 @@
+package getstarted
+
+import "testing"
+
+func TestProtoInfo_FileName(t *testing.T) {
+	var cases = []struct {
+		alias, want string
+	}{
+		{"FooBar", "foobar.proto"},
+		{"foo-bar", "foobar.proto"},
+		{"foo bar", "foobar.proto"},
+		{"foo_bar", "foo_bar.proto"},
+	}
+
+	for _, test := range cases {
+		p := protoInfo{
+			alias: test.alias,
+		}
+		if got, want := p.FileName(), test.want; got != want {
+			t.Errorf("Failed to generate correct filename for input %q; got %q, want %q", test.alias, got, want)
+		}
+	}
+}
+
+func TestProtoInfo_PackageName(t *testing.T) {
+	var cases = []struct {
+		alias, want string
+	}{
+		{"foobar", "foobar"},
+		{"foo-bar", "foobar"},
+		{"foo bar", "foobar"},
+		{"foo_bar", "foo_bar"},
+	}
+
+	for _, test := range cases {
+		p := protoInfo{
+			alias: test.alias,
+		}
+		if got, want := p.PackageName(), test.want; got != want {
+			t.Errorf("Failed to generate correct package name for input %q; got %q, want %q", test.alias, got, want)
+		}
+	}
+}
+
+func TestProtoInfo_ServiceName(t *testing.T) {
+	var cases = []struct {
+		alias, want string
+	}{
+		{"foobar", "Foobar"},
+		{"foo-bar", "FooBar"},
+		{"foo_bar", "FooBar"},
+		{"foo bar", "FooBar"},
+	}
+
+	for _, test := range cases {
+		p := protoInfo{
+			alias: test.alias,
+		}
+		if got, want := p.ServiceName(), test.want; got != want {
+			t.Errorf("Failed to generate correct service name for input %q; got %q, want %q", test.alias, got, want)
+		}
+	}
+}

--- a/truss/getstarted/template.go
+++ b/truss/getstarted/template.go
@@ -1,0 +1,48 @@
+package getstarted
+
+const starterProto = `
+syntax = "proto3";
+
+package {{.PackageName}};
+ 
+import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+
+service {{.ServiceName}} {
+  rpc Status(StatusRequest) returns (StatusResponse) {
+    option (google.api.http) = {
+      get: "/status"
+    };
+  }
+}
+
+enum ServiceStatus {
+  FAIL = 0;
+  OK = 1;
+}
+
+message StatusRequest {
+  bool full = 1;
+}
+
+message StatusResponse {
+  ServiceStatus status = 1;
+}
+`
+
+const nextStepMsg = `A "starter" protobuf file named '{{.FileName}}' has been created in the
+current directory. You can generate a service based on this new protobuf file
+at any time using the following command:
+
+    truss {{.FileName}}
+
+If you want to generate a protofile with a different name, use the
+'--getstarted' option with the name of your choice after '--getstarted'. For
+example, to generate a 'foo.proto', use the following command:
+
+    truss --getstarted foo
+`
+const existingFileMsg = `There's already a "starter" protobuf file named '{{.FileName}}' in the current
+directory. If you'd like to generate a service based on this existing protobuf
+file, you should instead run the command:
+
+    truss {{.FileName}}`


### PR DESCRIPTION
This PR adds the `--getstarted` flag to truss, which gives you a basic service-compatible protobuf file "out of the box". Here's what its output looks like:

```
$ truss --getstarted
INFO[0000] A "starter" protobuf file named 'getstarted.proto' has been created in the
current directory. You can generate a service based on this new protobuf file
at any time using the following command:

    truss getstarted.proto

If you want to generate a protofile with a different name, use the
'--getstarted' option with the name of your choice after '--getstarted'. For
example, to generate a 'foo.proto', use the following command:

    truss --getstarted foo
 
```

## Notes for reviewers:

In addition to the usual code review, please edit the english help messages in the `truss/getstarted/template.go` for consistency, tone, and grammar.