### PR TITLE
Update truss urls to the new repo location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
   - 1.8.x
   - 1.7.x
 
-go_import_path: github.com/TuneLab/go-truss
+go_import_path: github.com/TuneLab/truss
 
 before_install:
   # protobuf

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -14,19 +14,19 @@ Whenever templates are modified, the templates must be recompiled to binary,
 this is done with:
 
 ```
-$ go generate github.com/TuneLab/go-truss/...
+$ go generate github.com/TuneLab/truss/...
 ```
 
 Then to build truss and its protoc plugin to your $GOPATH/bin directory:
 
 ```
-$ go install github.com/TuneLab/go-truss/...
+$ go install github.com/TuneLab/truss/...
 ```
 
 Both can be done from the Makefile in the root directory:
 
 ```
-$ cd $GOPATH/github.com/TuneLab/go-truss
+$ cd $GOPATH/github.com/TuneLab/truss
 $ make
 ```
 
@@ -36,7 +36,7 @@ Before submitting a pull request always run tests that cover modified code.
 Also build truss and run truss's integration test. This can be done by
 
 ```
-$ cd $GOPATH/src/github.com/TuneLab/go-truss
+$ cd $GOPATH/src/github.com/TuneLab/truss
 $ make
 $ make test
 # If the tests failed and you want to remove generated code

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ RUN apk update && apk upgrade && apk add --no-cache protobuf git
 
 RUN go version && go get -u -v github.com/golang/protobuf/protoc-gen-go
 
-COPY ./ $GOPATH/src/github.com/TuneLab/go-truss
+COPY ./ $GOPATH/src/github.com/TuneLab/truss
 
-RUN go install -v github.com/TuneLab/go-truss/...
+RUN go install -v github.com/TuneLab/truss/...
 
 WORKDIR  /go/src/protos
 

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,12 @@ update-dependencies:
 
 # Generate go files containing the all template files in []byte form
 gobindata:
-	go generate github.com/TuneLab/go-truss/gengokit/template
+	go generate github.com/TuneLab/truss/gengokit/template
 
 # Install truss and protoc-gen-truss-protocast
 truss: gobindata
-	go install github.com/TuneLab/go-truss/cmd/protoc-gen-truss-protocast
-	go install -ldflags '-X "main.Version=$(SHA)" -X "main.VersionDate=$(VERSION_DATE)"' github.com/TuneLab/go-truss/cmd/truss
+	go install github.com/TuneLab/truss/cmd/protoc-gen-truss-protocast
+	go install -ldflags '-X "main.Version=$(SHA)" -X "main.VersionDate=$(VERSION_DATE)"' github.com/TuneLab/truss/cmd/truss
 
 # Run the go tests and the truss integration tests
 test: test-go test-integration

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Truss [![Build Status](https://travis-ci.org/TuneLab/go-truss.svg?branch=master)](https://travis-ci.org/TuneLab/go-truss)
+# Truss [![Build Status](https://travis-ci.org/TuneLab/truss.svg?branch=master)](https://travis-ci.org/TuneLab/truss)
 
 Truss handles the painful parts of services, freeing you to focus on the
 business logic.
@@ -29,8 +29,8 @@ Otherwise [install from source.](https://github.com/google/protobuf)
 1. Install Truss with
 
 	```
-	go get -u -d github.com/TuneLab/go-truss
-	cd $GOPATH/src/github.com/TuneLab/go-truss
+	go get -u -d github.com/TuneLab/truss
+	cd $GOPATH/src/github.com/TuneLab/truss
 	make dependencies
 	make
 	```

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -10,7 +10,7 @@ We will build a simple service based on [echo.proto](./_example/echo.proto)
   If everything passes you’re good to go.
   If you see any complaints about packages not installed, `go get` those packages
   If you encounter any other issues - ask the developers
-3. To update to newer version of truss, do `git pull`, or `go get -u github.com/TuneLab/go-truss/...` truss again.
+3. To update to newer version of truss, do `git pull`, or `go get -u github.com/TuneLab/truss/...` truss again.
 
 # Writing your first service
 
@@ -36,7 +36,7 @@ message LouderRequest {
 The RPC calls can be annotated with HTTP transport option (endpoint name and type of request). For this we must import the google annotations library.
 
 ```
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 service Echo {
 ...

--- a/_example/echo.proto
+++ b/_example/echo.proto
@@ -8,7 +8,7 @@ syntax = "proto3";
 // for `package echo;` truss will create the directory "echo-service".
 package echo;
 
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 service Echo {
   // Echo "echos" the incoming string

--- a/cmd/_integration-tests/Makefile
+++ b/cmd/_integration-tests/Makefile
@@ -21,10 +21,10 @@ all: test
 test: clean test-transport test-middlewares test-cli
 
 truss:
-	go install -ldflags '-X "main.Version=$(SHA)" -X "main.VersionDate=$(VERSION_DATE)"' github.com/TuneLab/go-truss/cmd/truss
+	go install -ldflags '-X "main.Version=$(SHA)" -X "main.VersionDate=$(VERSION_DATE)"' github.com/TuneLab/truss/cmd/truss
 
 protoc-gen-truss-protocast:
-	go build -o protoc-gen-truss-protocast github.com/TuneLab/go-truss/cmd/protoc-gen-truss-protocast
+	go build -o protoc-gen-truss-protocast github.com/TuneLab/truss/cmd/protoc-gen-truss-protocast
 
 test-transport: protoc-gen-truss-protocast truss
 	@which truss

--- a/cmd/_integration-tests/cli/cli_test.go
+++ b/cmd/_integration-tests/cli/cli_test.go
@@ -121,7 +121,7 @@ func TestBasicTypes(t *testing.T) {
 func TestBasicTypesWithPBOutFlag(t *testing.T) {
 	testEndToEnd("1-basic", "getbasic", t,
 		"--pbout",
-		"github.com/TuneLab/go-truss/cmd/_integration-tests/cli/test-service-definitions/1-basic/pbout")
+		"github.com/TuneLab/truss/cmd/_integration-tests/cli/test-service-definitions/1-basic/pbout")
 }
 
 func TestBasicTypesWithRelPBOutFlag(t *testing.T) {

--- a/cmd/_integration-tests/cli/test-service-definitions/1-basic/basic.proto
+++ b/cmd/_integration-tests/cli/test-service-definitions/1-basic/basic.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package basic;
 
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 service TEST {
   rpc GetBasic (BasicTypeRequest) returns (BasicTypeResponse) {

--- a/cmd/_integration-tests/cli/test-service-definitions/1-multifile/basic.proto
+++ b/cmd/_integration-tests/cli/test-service-definitions/1-multifile/basic.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package multifile;
 
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 import "imported.proto";
 

--- a/cmd/_integration-tests/cli/test-service-definitions/1-multifile/imported.proto
+++ b/cmd/_integration-tests/cli/test-service-definitions/1-multifile/imported.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package multifile;
 
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 message BasicTypeRequest {
   double A = 1;

--- a/cmd/_integration-tests/cli/test-service-definitions/2-repeated/repeated.proto
+++ b/cmd/_integration-tests/cli/test-service-definitions/2-repeated/repeated.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package Repeated;
 
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 service TEST {
   rpc GetRepeated (RepeatedTypeRequest) returns (RepeatedTypeResponse) {

--- a/cmd/_integration-tests/cli/test-service-definitions/3-nested/nested.proto
+++ b/cmd/_integration-tests/cli/test-service-definitions/3-nested/nested.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package nested;
 
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 service TEST {
   rpc GetNested (NestedTypeRequest) returns (NestedTypeResponse) {

--- a/cmd/_integration-tests/cli/test-service-definitions/4-maps/maps.proto
+++ b/cmd/_integration-tests/cli/test-service-definitions/4-maps/maps.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package map;
 
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 service TEST {
   rpc GetMap (MapTypeRequest) returns (MapTypeResponse) {

--- a/cmd/_integration-tests/cli/test-service-definitions/6-additional_bindings/additional_bindings.proto
+++ b/cmd/_integration-tests/cli/test-service-definitions/6-additional_bindings/additional_bindings.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package additional_bindings;
 
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 service TEST {
   rpc GetAdditional (BasicTypeRequest) returns (BasicTypeResponse) {

--- a/cmd/_integration-tests/middlewares/handlers/handlers.go
+++ b/cmd/_integration-tests/middlewares/handlers/handlers.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"golang.org/x/net/context"
 
-	pb "github.com/TuneLab/go-truss/cmd/_integration-tests/middlewares/middlewarestest-service"
+	pb "github.com/TuneLab/truss/cmd/_integration-tests/middlewares/middlewarestest-service"
 )
 
 // NewService returns a naïve, stateless implementation of Service.

--- a/cmd/_integration-tests/middlewares/middlewares-test.proto
+++ b/cmd/_integration-tests/middlewares/middlewares-test.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package middlewares;
 
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 service MiddlewaresTest {
   // Test endpoints.WrapAllExcept(middleware, exclude ...)

--- a/cmd/_integration-tests/middlewares/middlewares/endpoints.go
+++ b/cmd/_integration-tests/middlewares/middlewares/endpoints.go
@@ -4,7 +4,7 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	"golang.org/x/net/context"
 
-	svc "github.com/TuneLab/go-truss/cmd/_integration-tests/middlewares/middlewarestest-service/svc"
+	svc "github.com/TuneLab/truss/cmd/_integration-tests/middlewares/middlewarestest-service/svc"
 )
 
 // WrapEndpoints accepts the service's entire collection of endpoints, so that a

--- a/cmd/_integration-tests/middlewares/middlewares/service.go
+++ b/cmd/_integration-tests/middlewares/middlewares/service.go
@@ -1,7 +1,7 @@
 package middlewares
 
 import (
-	pb "github.com/TuneLab/go-truss/cmd/_integration-tests/middlewares/middlewarestest-service"
+	pb "github.com/TuneLab/truss/cmd/_integration-tests/middlewares/middlewarestest-service"
 )
 
 func WrapService(in pb.MiddlewaresTestServer) pb.MiddlewaresTestServer {

--- a/cmd/_integration-tests/middlewares/middlewares_test.go
+++ b/cmd/_integration-tests/middlewares/middlewares_test.go
@@ -6,7 +6,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	pb "github.com/TuneLab/go-truss/cmd/_integration-tests/middlewares/middlewarestest-service"
+	pb "github.com/TuneLab/truss/cmd/_integration-tests/middlewares/middlewarestest-service"
 )
 
 func TestAlwaysWrapped(t *testing.T) {

--- a/cmd/_integration-tests/middlewares/setup_test.go
+++ b/cmd/_integration-tests/middlewares/setup_test.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"testing"
 
-	pb "github.com/TuneLab/go-truss/cmd/_integration-tests/middlewares/middlewarestest-service"
-	handler "github.com/TuneLab/go-truss/cmd/_integration-tests/middlewares/middlewarestest-service/handlers"
-	"github.com/TuneLab/go-truss/cmd/_integration-tests/middlewares/middlewarestest-service/middlewares"
-	svc "github.com/TuneLab/go-truss/cmd/_integration-tests/middlewares/middlewarestest-service/svc"
+	pb "github.com/TuneLab/truss/cmd/_integration-tests/middlewares/middlewarestest-service"
+	handler "github.com/TuneLab/truss/cmd/_integration-tests/middlewares/middlewarestest-service/handlers"
+	"github.com/TuneLab/truss/cmd/_integration-tests/middlewares/middlewarestest-service/middlewares"
+	svc "github.com/TuneLab/truss/cmd/_integration-tests/middlewares/middlewarestest-service/svc"
 )
 
 var middlewareEndpoints svc.Endpoints

--- a/cmd/_integration-tests/transport/grpc_test.go
+++ b/cmd/_integration-tests/transport/grpc_test.go
@@ -8,8 +8,8 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
-	pb "github.com/TuneLab/go-truss/cmd/_integration-tests/transport/transportpermutations-service"
-	grpcclient "github.com/TuneLab/go-truss/cmd/_integration-tests/transport/transportpermutations-service/svc/client/grpc"
+	pb "github.com/TuneLab/truss/cmd/_integration-tests/transport/transportpermutations-service"
+	grpcclient "github.com/TuneLab/truss/cmd/_integration-tests/transport/transportpermutations-service/svc/client/grpc"
 )
 
 var grpcAddr string

--- a/cmd/_integration-tests/transport/handlers/handlers.go
+++ b/cmd/_integration-tests/transport/handlers/handlers.go
@@ -9,7 +9,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	pb "github.com/TuneLab/go-truss/cmd/_integration-tests/transport/transportpermutations-service"
+	pb "github.com/TuneLab/truss/cmd/_integration-tests/transport/transportpermutations-service"
 )
 
 // NewService returns a naïve, stateless implementation of Service.

--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -14,8 +14,8 @@ import (
 	// 3d Party
 	"golang.org/x/net/context"
 	// This Service
-	pb "github.com/TuneLab/go-truss/cmd/_integration-tests/transport/transportpermutations-service"
-	httpclient "github.com/TuneLab/go-truss/cmd/_integration-tests/transport/transportpermutations-service/svc/client/http"
+	pb "github.com/TuneLab/truss/cmd/_integration-tests/transport/transportpermutations-service"
+	httpclient "github.com/TuneLab/truss/cmd/_integration-tests/transport/transportpermutations-service/svc/client/http"
 
 	"github.com/pkg/errors"
 )

--- a/cmd/_integration-tests/transport/setup_test.go
+++ b/cmd/_integration-tests/transport/setup_test.go
@@ -15,9 +15,9 @@ import (
 	// Go Kit
 	"github.com/go-kit/kit/log"
 
-	pb "github.com/TuneLab/go-truss/cmd/_integration-tests/transport/transportpermutations-service"
-	handler "github.com/TuneLab/go-truss/cmd/_integration-tests/transport/transportpermutations-service/handlers"
-	svc "github.com/TuneLab/go-truss/cmd/_integration-tests/transport/transportpermutations-service/svc"
+	pb "github.com/TuneLab/truss/cmd/_integration-tests/transport/transportpermutations-service"
+	handler "github.com/TuneLab/truss/cmd/_integration-tests/transport/transportpermutations-service/handlers"
+	svc "github.com/TuneLab/truss/cmd/_integration-tests/transport/transportpermutations-service/svc"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/_integration-tests/transport/transport-test.proto
+++ b/cmd/_integration-tests/transport/transport-test.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package transport;
 
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 service TransportPermutations {
   rpc GetWithQuery (GetWithQueryRequest) returns (GetWithQueryResponse) {

--- a/cmd/truss/main.go
+++ b/cmd/truss/main.go
@@ -13,16 +13,16 @@ import (
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
 
-	"github.com/TuneLab/go-truss/truss"
-	"github.com/TuneLab/go-truss/truss/execprotoc"
-	"github.com/TuneLab/go-truss/truss/getstarted"
-	"github.com/TuneLab/go-truss/truss/parsesvcname"
+	"github.com/TuneLab/truss/truss"
+	"github.com/TuneLab/truss/truss/execprotoc"
+	"github.com/TuneLab/truss/truss/getstarted"
+	"github.com/TuneLab/truss/truss/parsesvcname"
 
-	"github.com/TuneLab/go-truss/deftree"
-	"github.com/TuneLab/go-truss/gendoc"
-	ggkconf "github.com/TuneLab/go-truss/gengokit"
-	gengokit "github.com/TuneLab/go-truss/gengokit/generator"
-	"github.com/TuneLab/go-truss/svcdef"
+	"github.com/TuneLab/truss/deftree"
+	"github.com/TuneLab/truss/gendoc"
+	ggkconf "github.com/TuneLab/truss/gengokit"
+	gengokit "github.com/TuneLab/truss/gengokit/generator"
+	"github.com/TuneLab/truss/svcdef"
 )
 
 var (
@@ -461,7 +461,7 @@ Do you want to automatically run 'make' and rerun command:
 	return false
 }
 
-const trussImportPath = "github.com/TuneLab/go-truss"
+const trussImportPath = "github.com/TuneLab/truss"
 
 // makeAndRunTruss installs truss by running make in trussImportPath.
 // It then passes through args to newly installed truss.

--- a/deftree/associate_comments_test.go
+++ b/deftree/associate_comments_test.go
@@ -10,7 +10,7 @@ func TestCommentedEnum(t *testing.T) {
 	defStr := `
 		syntax = "proto3";
 		package general;
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		enum FooBarBaz {
 			// This is my comment, this is my note

--- a/deftree/build_deftree.go
+++ b/deftree/build_deftree.go
@@ -18,8 +18,8 @@ import (
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"github.com/pkg/errors"
 
-	"github.com/TuneLab/go-truss/deftree/svcparse"
-	"github.com/TuneLab/go-truss/truss/execprotoc"
+	"github.com/TuneLab/truss/deftree/svcparse"
+	"github.com/TuneLab/truss/truss/execprotoc"
 )
 
 var gengo *generator.Generator

--- a/deftree/build_deftree_test.go
+++ b/deftree/build_deftree_test.go
@@ -9,7 +9,7 @@ import (
 	// This has to be imported because it modifies the state of `proto` by
 	// registering the `google.api.http` extension, allowing us to specify it
 	// in the sources below.
-	_ "github.com/TuneLab/go-truss/deftree/googlethirdparty"
+	_ "github.com/TuneLab/truss/deftree/googlethirdparty"
 
 	"github.com/golang/protobuf/proto"
 	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
@@ -28,7 +28,7 @@ func TestNewFromString(t *testing.T) {
 		// General package
 		package general;
 
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		// RequestMessage is so foo
 		message RequestMessage {

--- a/deftree/googlethirdparty/annotations.proto
+++ b/deftree/googlethirdparty/annotations.proto
@@ -18,8 +18,8 @@ syntax = "proto3";
 
 package google.api;
 
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/http.proto"; // from google/api/http.proto // modified
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/descriptor.proto"; // from google/protobuf/descriptor.proto // modified
+import "github.com/TuneLab/truss/deftree/googlethirdparty/http.proto"; // from google/api/http.proto // modified
+import "github.com/TuneLab/truss/deftree/googlethirdparty/descriptor.proto"; // from google/protobuf/descriptor.proto // modified
 
 option java_multiple_files = true;
 option java_outer_classname = "AnnotationsProto";

--- a/gendoc/gendoc.go
+++ b/gendoc/gendoc.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/TuneLab/go-truss/deftree"
+	"github.com/TuneLab/truss/deftree"
 )
 
 func findServiceName(md *deftree.MicroserviceDefinition) string {

--- a/gendoc/generate_markdown.go
+++ b/gendoc/generate_markdown.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/TuneLab/go-truss/deftree"
+	"github.com/TuneLab/truss/deftree"
 )
 
 // prindent is a utility function for creating a formatted string with a given

--- a/gengokit/clientarggen/client_argument_generator.go
+++ b/gengokit/clientarggen/client_argument_generator.go
@@ -14,7 +14,7 @@ import (
 	gogen "github.com/golang/protobuf/protoc-gen-go/generator"
 	"github.com/pkg/errors"
 
-	"github.com/TuneLab/go-truss/svcdef"
+	"github.com/TuneLab/truss/svcdef"
 )
 
 // A collection of the necessary information for generating basic business

--- a/gengokit/clientarggen/client_argument_generator_test.go
+++ b/gengokit/clientarggen/client_argument_generator_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 
-	"github.com/TuneLab/go-truss/gengokit/gentesthelper"
-	"github.com/TuneLab/go-truss/svcdef"
+	"github.com/TuneLab/truss/gengokit/gentesthelper"
+	"github.com/TuneLab/truss/svcdef"
 )
 
 var (
@@ -31,7 +31,7 @@ func TestNewClientServiceArgs(t *testing.T) {
 		// General package
 		package general;
 
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		message SumRequest {
 			repeated int64 a = 1;

--- a/gengokit/generator/gen.go
+++ b/gengokit/generator/gen.go
@@ -11,12 +11,12 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
 
-	"github.com/TuneLab/go-truss/gengokit"
-	"github.com/TuneLab/go-truss/gengokit/handler"
-	"github.com/TuneLab/go-truss/gengokit/middlewares"
-	templFiles "github.com/TuneLab/go-truss/gengokit/template"
+	"github.com/TuneLab/truss/gengokit"
+	"github.com/TuneLab/truss/gengokit/handler"
+	"github.com/TuneLab/truss/gengokit/middlewares"
+	templFiles "github.com/TuneLab/truss/gengokit/template"
 
-	"github.com/TuneLab/go-truss/svcdef"
+	"github.com/TuneLab/truss/svcdef"
 )
 
 // GenerateGokit returns a gokit service generated from a service definition (svcdef),

--- a/gengokit/generator/gen_test.go
+++ b/gengokit/generator/gen_test.go
@@ -11,11 +11,11 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/TuneLab/go-truss/gengokit"
-	templateFileAssets "github.com/TuneLab/go-truss/gengokit/template"
-	"github.com/TuneLab/go-truss/svcdef"
+	"github.com/TuneLab/truss/gengokit"
+	templateFileAssets "github.com/TuneLab/truss/gengokit/template"
+	"github.com/TuneLab/truss/svcdef"
 
-	"github.com/TuneLab/go-truss/gengokit/gentesthelper"
+	"github.com/TuneLab/truss/gengokit/gentesthelper"
 )
 
 var gopath []string
@@ -49,7 +49,7 @@ func TestApplyTemplateFromPath(t *testing.T) {
 		// General package
 		package general;
 
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		// RequestMessage is so foo
 		message RequestMessage {
@@ -78,8 +78,8 @@ func TestApplyTemplateFromPath(t *testing.T) {
 	}
 
 	conf := gengokit.Config{
-		GoPackage: "github.com/TuneLab/go-truss",
-		PBPackage: "github.com/TuneLab/go-truss/gengokit/general-service",
+		GoPackage: "github.com/TuneLab/truss",
+		PBPackage: "github.com/TuneLab/truss/gengokit/general-service",
 	}
 
 	te, err := gengokit.NewData(sd, conf)
@@ -132,8 +132,8 @@ func stringToTemplateExector(def, importPath string) (*gengokit.Data, error) {
 }
 
 func TestAllTemplates(t *testing.T) {
-	const goPackage = "github.com/TuneLab/go-truss/gengokit"
-	const goPBPackage = "github.com/TuneLab/go-truss/gengokit/general-service"
+	const goPackage = "github.com/TuneLab/truss/gengokit"
+	const goPBPackage = "github.com/TuneLab/truss/gengokit/general-service"
 
 	const def = `
 		syntax = "proto3";
@@ -141,7 +141,7 @@ func TestAllTemplates(t *testing.T) {
 		// General package
 		package general;
 
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		// RequestMessage is so foo
 		message RequestMessage {
@@ -171,7 +171,7 @@ func TestAllTemplates(t *testing.T) {
 		// General package
 		package general;
 
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		// RequestMessage is so foo
 		message RequestMessage {
@@ -213,8 +213,8 @@ func TestAllTemplates(t *testing.T) {
 	}
 
 	conf := gengokit.Config{
-		GoPackage: "github.com/TuneLab/go-truss/gengokit",
-		PBPackage: "github.com/TuneLab/go-truss/gengokit/general-service",
+		GoPackage: "github.com/TuneLab/truss/gengokit",
+		PBPackage: "github.com/TuneLab/truss/gengokit/general-service",
 	}
 
 	data1, err := gengokit.NewData(sd1, conf)

--- a/gengokit/gengokit.go
+++ b/gengokit/gengokit.go
@@ -9,9 +9,9 @@ import (
 	generatego "github.com/golang/protobuf/protoc-gen-go/generator"
 	"github.com/pkg/errors"
 
-	"github.com/TuneLab/go-truss/gengokit/clientarggen"
-	"github.com/TuneLab/go-truss/gengokit/httptransport"
-	"github.com/TuneLab/go-truss/svcdef"
+	"github.com/TuneLab/truss/gengokit/clientarggen"
+	"github.com/TuneLab/truss/gengokit/httptransport"
+	"github.com/TuneLab/truss/svcdef"
 )
 
 type Renderable interface {

--- a/gengokit/gengokit_test.go
+++ b/gengokit/gengokit_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/TuneLab/go-truss/svcdef"
+	"github.com/TuneLab/truss/svcdef"
 )
 
 var gopath []string
@@ -21,7 +21,7 @@ func TestNewData(t *testing.T) {
 		// General package
 		package general;
 
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		// RequestMessage is so foo
 		message RequestMessage {
@@ -50,8 +50,8 @@ func TestNewData(t *testing.T) {
 	}
 
 	conf := Config{
-		GoPackage: "github.com/TuneLab/go-truss/gengokit/general-service",
-		PBPackage: "github.com/TuneLab/go-truss/gengokit/general-service",
+		GoPackage: "github.com/TuneLab/truss/gengokit/general-service",
+		PBPackage: "github.com/TuneLab/truss/gengokit/general-service",
 	}
 
 	te, err := NewData(sd, conf)

--- a/gengokit/handler/handler.go
+++ b/gengokit/handler/handler.go
@@ -14,8 +14,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
 
-	"github.com/TuneLab/go-truss/gengokit"
-	"github.com/TuneLab/go-truss/svcdef"
+	"github.com/TuneLab/truss/gengokit"
+	"github.com/TuneLab/truss/svcdef"
 )
 
 // NewService is an exported func that creates a new service

--- a/gengokit/handler/handler_test.go
+++ b/gengokit/handler/handler_test.go
@@ -14,9 +14,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
 
-	"github.com/TuneLab/go-truss/gengokit"
-	helper "github.com/TuneLab/go-truss/gengokit/gentesthelper"
-	"github.com/TuneLab/go-truss/svcdef"
+	"github.com/TuneLab/truss/gengokit"
+	helper "github.com/TuneLab/truss/gengokit/gentesthelper"
+	"github.com/TuneLab/truss/svcdef"
 )
 
 var gopath []string
@@ -38,7 +38,7 @@ func TestServerMethsTempl(t *testing.T) {
 		// General package
 		package general;
 
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		// RequestMessage is so foo
 		message RequestMessage {
@@ -98,7 +98,7 @@ func TestApplyServerTempl(t *testing.T) {
 		// General package
 		package general;
 
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		// RequestMessage is so foo
 		message RequestMessage {
@@ -122,8 +122,8 @@ func TestApplyServerTempl(t *testing.T) {
 		}
 	`
 	conf := gengokit.Config{
-		GoPackage: "github.com/TuneLab/go-truss/gengokit/general-service",
-		PBPackage: "github.com/TuneLab/go-truss/gengokit/general-service",
+		GoPackage: "github.com/TuneLab/truss/gengokit/general-service",
+		PBPackage: "github.com/TuneLab/truss/gengokit/general-service",
 	}
 	sd, err := svcdef.NewFromString(def, gopath)
 	if err != nil {
@@ -139,7 +139,7 @@ func TestApplyServerTempl(t *testing.T) {
 		import (
 			"golang.org/x/net/context"
 
-			pb "github.com/TuneLab/go-truss/gengokit/general-service"
+			pb "github.com/TuneLab/truss/gengokit/general-service"
 		)
 
 		// NewService returns a naïve, stateless implementation of Service.
@@ -190,7 +190,7 @@ func TestIsValidFunc(t *testing.T) {
 		// General package
 		package general;
 
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		// RequestMessage is so foo
 		message RequestMessage {
@@ -259,7 +259,7 @@ func TestPruneDecls(t *testing.T) {
 		// General package
 		package general;
 
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		// RequestMessage is so foo
 		message RequestMessage {
@@ -309,7 +309,7 @@ func TestPruneDecls(t *testing.T) {
 		import (
 			"golang.org/x/net/context"
 
-			pb "github.com/TuneLab/go-truss/gengokit/general-service"
+			pb "github.com/TuneLab/truss/gengokit/general-service"
 		)
 
 		// NewService returns a naïve, stateless implementation of Service.
@@ -386,7 +386,7 @@ func TestUpdateMethods(t *testing.T) {
 		// General package
 		package general;
 
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		// RequestMessage is so foo
 		message RequestMessage {
@@ -442,8 +442,8 @@ func TestUpdateMethods(t *testing.T) {
 	allMethods := svc.Methods
 
 	conf := gengokit.Config{
-		GoPackage: "github.com/TuneLab/go-truss/gengokit",
-		PBPackage: "github.com/TuneLab/go-truss/gengokit/general-service",
+		GoPackage: "github.com/TuneLab/truss/gengokit",
+		PBPackage: "github.com/TuneLab/truss/gengokit/general-service",
 	}
 
 	te, err := gengokit.NewData(sd, conf)

--- a/gengokit/handler/hooks.go
+++ b/gengokit/handler/hooks.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/TuneLab/go-truss/gengokit"
+	"github.com/TuneLab/truss/gengokit"
 )
 
 const HookPath = "handlers/hooks.gotemplate"

--- a/gengokit/httptransport/httptransport.go
+++ b/gengokit/httptransport/httptransport.go
@@ -15,8 +15,8 @@ import (
 	gogen "github.com/golang/protobuf/protoc-gen-go/generator"
 	"github.com/pkg/errors"
 
-	"github.com/TuneLab/go-truss/gengokit/httptransport/templates"
-	"github.com/TuneLab/go-truss/svcdef"
+	"github.com/TuneLab/truss/gengokit/httptransport/templates"
+	"github.com/TuneLab/truss/svcdef"
 )
 
 // Helper is the base struct for the data structure containing all the

--- a/gengokit/httptransport/httptransport_test.go
+++ b/gengokit/httptransport/httptransport_test.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/TuneLab/go-truss/gengokit/gentesthelper"
-	"github.com/TuneLab/go-truss/svcdef"
+	"github.com/TuneLab/truss/gengokit/gentesthelper"
+	"github.com/TuneLab/truss/svcdef"
 	"github.com/davecgh/go-spew/spew"
 )
 
@@ -28,7 +28,7 @@ func TestNewMethod(t *testing.T) {
 		// General package
 		package general;
 
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		message SumRequest {
 			int64 a = 1;

--- a/gengokit/httptransport/templates_test.go
+++ b/gengokit/httptransport/templates_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/TuneLab/go-truss/gengokit/gentesthelper"
-	"github.com/TuneLab/go-truss/gengokit/httptransport/templates"
+	"github.com/TuneLab/truss/gengokit/gentesthelper"
+	"github.com/TuneLab/truss/gengokit/httptransport/templates"
 )
 
 // Test that rendering certain templates will ouput the code we expect. The

--- a/gengokit/middlewares/middlewares.go
+++ b/gengokit/middlewares/middlewares.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/TuneLab/go-truss/gengokit"
-	"github.com/TuneLab/go-truss/gengokit/middlewares/templates"
+	"github.com/TuneLab/truss/gengokit"
+	"github.com/TuneLab/truss/gengokit/middlewares/templates"
 )
 
 // EndpointsPath is the path to the Endpoints middleware file that package middlewares renders

--- a/gengokit/middlewares/middlewares_test.go
+++ b/gengokit/middlewares/middlewares_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/TuneLab/go-truss/gengokit"
-	thelper "github.com/TuneLab/go-truss/gengokit/gentesthelper"
-	"github.com/TuneLab/go-truss/svcdef"
+	"github.com/TuneLab/truss/gengokit"
+	thelper "github.com/TuneLab/truss/gengokit/gentesthelper"
+	"github.com/TuneLab/truss/svcdef"
 )
 
 var gopath []string
@@ -23,7 +23,7 @@ func TestNewServiceMiddleware(t *testing.T) {
 		package middlewares
 
 		import (
-		pb "github.com/TuneLab/go-truss/gengokit/general-service"
+		pb "github.com/TuneLab/truss/gengokit/general-service"
 		)
 
 		func WrapService(in pb.ProtoServiceServer) pb.ProtoServiceServer {
@@ -58,7 +58,7 @@ func TestRenderPrevService(t *testing.T) {
 		package middlewares
 
 		import (
-			pb "github.com/TuneLab/go-truss/gengokit/general-service"
+			pb "github.com/TuneLab/truss/gengokit/general-service"
 		)
 
 		func WrapService(in pb.ProtoServiceServer) pb.ProtoServiceServer {
@@ -100,7 +100,7 @@ func TestRenderPrevEndpoints(t *testing.T) {
 
 		import (
 			"github.com/go-kit/kit/endpoint"
-			"github.com/TuneLab/go-truss/gengokit/general-service/svc"
+			"github.com/TuneLab/truss/gengokit/general-service/svc"
 		)
 
 		// WrapEndpoint will be called individually for all endpoints defined in
@@ -171,7 +171,7 @@ func generalService() (*svcdef.Svcdef, *gengokit.Data, error) {
 		// General package
 		package general;
 
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		// RequestMessage is so foo
 		message RequestMessage {
@@ -199,8 +199,8 @@ func generalService() (*svcdef.Svcdef, *gengokit.Data, error) {
 		return nil, nil, err
 	}
 	conf := gengokit.Config{
-		GoPackage: "github.com/TuneLab/go-truss/gengokit/general-service",
-		PBPackage: "github.com/TuneLab/go-truss/gengokit/general-service",
+		GoPackage: "github.com/TuneLab/truss/gengokit/general-service",
+		PBPackage: "github.com/TuneLab/truss/gengokit/general-service",
 	}
 
 	data, err := gengokit.NewData(sd, conf)

--- a/gengokit/middlewares/templates/endpoints.go
+++ b/gengokit/middlewares/templates/endpoints.go
@@ -24,7 +24,7 @@ func WrapEndpoints(in svc.Endpoints) svc.Endpoints {
 	// These middlewares get passed the endpoints name as their first argument when applied.
 	// This can be used to write generic metric gathering middlewares that can
 	// report the endpoint name for free.
-	// github.com/TuneLab/go-truss/_example/middlewares/labeledmiddlewares.go for examples.
+	// github.com/TuneLab/truss/_example/middlewares/labeledmiddlewares.go for examples.
 	// in.WrapAllLabeledExcept(errorCounter(statsdCounter), "Status", "Ping")
 
 	// How to apply a middleware to a single endpoint.

--- a/svcdef/consolidate_http.go
+++ b/svcdef/consolidate_http.go
@@ -11,7 +11,7 @@ import (
 
 	gogen "github.com/golang/protobuf/protoc-gen-go/generator"
 
-	"github.com/TuneLab/go-truss/deftree/svcparse"
+	"github.com/TuneLab/truss/deftree/svcparse"
 )
 
 type optional interface {

--- a/svcdef/consolidate_http_test.go
+++ b/svcdef/consolidate_http_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/TuneLab/go-truss/deftree/svcparse"
+	"github.com/TuneLab/truss/deftree/svcparse"
 )
 
 func TestGetPathParams(t *testing.T) {
@@ -56,7 +56,7 @@ type MapServer interface {
 	protoCode := `
 syntax = "proto3";
 package TEST;
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 enum EnumType {
   A = 0;

--- a/svcdef/newfromstring.go
+++ b/svcdef/newfromstring.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/TuneLab/go-truss/truss/execprotoc"
+	"github.com/TuneLab/truss/truss/execprotoc"
 	"github.com/pkg/errors"
 )
 

--- a/svcdef/newfromstring_test.go
+++ b/svcdef/newfromstring_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/TuneLab/go-truss/gengokit/gentesthelper"
+	"github.com/TuneLab/truss/gengokit/gentesthelper"
 	"github.com/davecgh/go-spew/spew"
 )
 
@@ -23,7 +23,7 @@ func basicFromString(t *testing.T) *Svcdef {
 		// General package
 		package general;
 
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		message SumRequest {
 			int64 a = 1;
@@ -164,7 +164,7 @@ func TestNoHTTPBinding(t *testing.T) {
 		// General package
 		package general;
 
-		import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 		message SumRequest {
 			int64 a = 1;

--- a/svcdef/test-go.txt
+++ b/svcdef/test-go.txt
@@ -27,7 +27,7 @@ package TEST
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/TuneLab/go-truss/pbinfo/scrap/third_party/googleapis/google/api"
+import _ "github.com/TuneLab/truss/pbinfo/scrap/third_party/googleapis/google/api"
 
 import (
 	context "golang.org/x/net/context"

--- a/svcdef/test-proto.txt
+++ b/svcdef/test-proto.txt
@@ -3,7 +3,7 @@ syntax = "proto3";
 
 package TEST;
 
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 service Map {
   rpc GetMap (MapTypeRequest) returns (MapTypeResponse) {

--- a/truss/getstarted/template.go
+++ b/truss/getstarted/template.go
@@ -5,7 +5,7 @@ syntax = "proto3";
 
 package {{.PackageName}};
 
-import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 service {{.ServiceName}} {
   rpc Status(StatusRequest) returns (StatusResponse) {

--- a/truss/parsesvcname/parsesvcname.go
+++ b/truss/parsesvcname/parsesvcname.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/TuneLab/go-truss/svcdef"
-	"github.com/TuneLab/go-truss/truss/execprotoc"
+	"github.com/TuneLab/truss/svcdef"
+	"github.com/TuneLab/truss/truss/execprotoc"
 	"github.com/pkg/errors"
 )
 

--- a/truss/parsesvcname/parsesvcname_test.go
+++ b/truss/parsesvcname/parsesvcname_test.go
@@ -15,7 +15,7 @@ func TestFromPaths(t *testing.T) {
 	syntax = "proto3";
 	package echo;
 
-	import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+	import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 	service BounceEcho {
 	  rpc Echo (EchoRequest) returns (EchoResponse) {
@@ -61,7 +61,7 @@ func TestFromReader(t *testing.T) {
 	syntax = "proto3";
 	package echo;
 
-	import "github.com/TuneLab/go-truss/deftree/googlethirdparty/annotations.proto";
+	import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
 
 	service BounceEcho {
 	  rpc Echo (EchoRequest) returns (EchoResponse) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -213,5 +213,5 @@
 			"revisionTime": "2017-01-27T15:26:01Z"
 		}
 	],
-	"rootPath": "github.com/TuneLab/go-truss"
+	"rootPath": "github.com/TuneLab/truss"
 }


### PR DESCRIPTION
This PR is a wholesale migration to the new repository URL.

With the recent change of the url for this repo from `https://github.com/TuneLab/go-truss/` to `https://github.com/TuneLab/truss`, all references in the repo are now out of date. Examples of this can be found in code imports and in the documentation.

 I made this change with the following command:

    ag-replace "TuneLab/go-truss" "TuneLab/truss"

The `ag-replace` command is a script for just this kind of mass-rename, and can be found here: https://gist.github.com/adamryman/1de22e36a14c29da2f41c8512cb86b6d/

Note, two files which are normally ignored by git, and thus `ag`, had to be edited by hand. They where: `.travis.yml`, and `_example/echo.proto`.