### PR TITLE
Initial work: Add benchmarks for truss HTTP pipeline

### DIFF
--- a/cmd/_integration-tests/transport/Makefile
+++ b/cmd/_integration-tests/transport/Makefile
@@ -21,6 +21,7 @@ test:
 	truss transport-test.proto
 	@echo -e '$(TEST_RUNNING_MSG)'
 	go test -v
+	go test -run=XXX -bench=.
 	$(MAKE) clean
 
 # Run this when you add a new rpc to the .proto file and it will update

--- a/cmd/_integration-tests/transport/Makefile
+++ b/cmd/_integration-tests/transport/Makefile
@@ -9,6 +9,13 @@ TEST_RUNNING_MSG=\n$(OK_COLOR)Running transport tests:$(END_COLOR_LINE)
 
 TRUSS_AGAIN_MSG=\n$(OK_COLOR)Running Truss... again, to test regeneration$(END_COLOR_LINE)
 
+# make test match=test_to_run
+match := $(match)
+ifndef match
+	match := .
+endif
+
+
 all: test
 
 setup:
@@ -18,15 +25,15 @@ setup:
 
 test: setup
 	@echo -e '$(TEST_RUNNING_MSG)'
-	go test -v
+	go test -run=$(match) -v
 	@echo -e '$(TRUSS_AGAIN_MSG)'
 	truss transport-test.proto
 	@echo -e '$(TEST_RUNNING_MSG)'
-	go test -v
+	go test -run=$(match)-v
 	$(MAKE) clean
 
 bench: setup
-	go test -run=XXX -bench=.
+	go test -run=XXX -bench=$(match)
 	$(MAKE) clean
 
 

--- a/cmd/_integration-tests/transport/Makefile
+++ b/cmd/_integration-tests/transport/Makefile
@@ -11,18 +11,24 @@ TRUSS_AGAIN_MSG=\n$(OK_COLOR)Running Truss... again, to test regeneration$(END_C
 
 all: test
 
-test:
+setup:
 	@echo -e '$(TRUSS_MSG)'
 	truss transport-test.proto
 	cp -r handlers transportpermutations-service
+
+test: setup
 	@echo -e '$(TEST_RUNNING_MSG)'
 	go test -v
 	@echo -e '$(TRUSS_AGAIN_MSG)'
 	truss transport-test.proto
 	@echo -e '$(TEST_RUNNING_MSG)'
 	go test -v
+	$(MAKE) clean
+
+bench: setup
 	go test -run=XXX -bench=.
 	$(MAKE) clean
+
 
 # Run this when you add a new rpc to the .proto file and it will update
 # handlers/handlers.go

--- a/cmd/_integration-tests/transport/Makefile
+++ b/cmd/_integration-tests/transport/Makefile
@@ -33,7 +33,7 @@ test: setup
 	$(MAKE) clean
 
 bench: setup
-	go test -run=XXX -bench=$(match)
+	go test -run=XXX -bench=$(match) -benchmem
 	$(MAKE) clean
 
 

--- a/cmd/_integration-tests/transport/http_benchmarks_test.go
+++ b/cmd/_integration-tests/transport/http_benchmarks_test.go
@@ -1,0 +1,121 @@
+package test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	// 3d Party
+	"golang.org/x/net/context"
+
+	pb "github.com/TuneLab/truss/cmd/_integration-tests/transport/transportpermutations-service"
+	httpclient "github.com/TuneLab/truss/cmd/_integration-tests/transport/transportpermutations-service/svc/client/http"
+
+	"github.com/TuneLab/truss/cmd/_integration-tests/transport/transportpermutations-service/handlers"
+	"github.com/TuneLab/truss/cmd/_integration-tests/transport/transportpermutations-service/middlewares"
+	"github.com/TuneLab/truss/cmd/_integration-tests/transport/transportpermutations-service/svc"
+
+	httptransport "github.com/go-kit/kit/transport/http"
+)
+
+var assignval interface{}
+
+// See how fast it is to make a full RPC complete with actual (local) HTTP connection
+func BenchmarkGetWithQueryClient(b *testing.B) {
+	var req pb.GetWithQueryRequest
+	req.A = 12
+	req.B = 45360
+
+	svchttp, err := httpclient.New(httpAddr, httpclient.CtxValuesToSend("request-url", "transport"))
+	if err != nil {
+		b.Fatalf("failed to create httpclient: %q", err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resp, err := svchttp.GetWithQuery(context.Background(), &req)
+		if err != nil {
+			b.Fatalf("httpclient returned error: %q", err)
+		}
+		assignval = resp
+	}
+}
+
+type ServerTestData struct {
+	r        *http.Request
+	recorder *httptest.ResponseRecorder
+}
+
+// Instead of actually sending a request over the network, instead we construct
+// the service endpoints within this function and call it's method directly.
+func BenchmarkGetWithQueryClient_NoNetwork(b *testing.B) {
+	// Create the server for http transport, but without actually having it
+	// serve HTTP requests. Instead we're going to pass it a pre-constructed
+	// HTTP request directly.
+	var service pb.TransportPermutationsServer
+	{
+		service = handlers.NewService()
+		// Wrap Service with middlewares. See middlewares/service.go
+		service = middlewares.WrapService(service)
+	}
+	var getwithqueryEndpoint = svc.MakeGetWithQueryEndpoint(service)
+	endpoints := svc.Endpoints{
+		GetWithQueryEndpoint: getwithqueryEndpoint,
+	}
+	ctx := context.WithValue(context.Background(), "request-url", "/getwithquery")
+	ctx = context.WithValue(ctx, "transport", "HTTPJSON")
+	server := httptransport.NewServer(
+		// This is definitely a hack
+		ctx,
+		endpoints.GetWithQueryEndpoint,
+		svc.DecodeHTTPGetWithQueryZeroRequest,
+		svc.EncodeHTTPGenericResponse,
+	)
+	var req pb.GetWithQueryRequest
+	req.A = 12
+	req.B = 45360
+
+	var testData []ServerTestData
+	for i := 0; i < b.N; i++ {
+		httpreq, _ := http.NewRequest("GET", "http://localhost/getwithquery", strings.NewReader(string("")))
+		httpclient.EncodeHTTPGetWithQueryZeroRequest(context.Background(), httpreq, &req)
+		resprecorder := httptest.NewRecorder()
+
+		item := ServerTestData{
+			r:        httpreq,
+			recorder: resprecorder,
+		}
+
+		testData = append(testData, item)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		server.ServeHTTP(testData[i].recorder, testData[i].r)
+	}
+}
+
+// Benchmark the speed of encoding an HTTP request
+func BenchmarkClientEncoding(b *testing.B) {
+	var req pb.GetWithQueryRequest
+	req.A = 12
+	req.B = 45360
+	for i := 0; i < b.N; i++ {
+		httpreq, _ := http.NewRequest("GET", "http://localhost/getwithquery", strings.NewReader(string("")))
+		httpclient.EncodeHTTPGetWithQueryZeroRequest(context.Background(), httpreq, &req)
+	}
+}
+
+// This provides a baseline "minimum speed" benchmark
+func BenchmarkAddition(b *testing.B) {
+	A := "12"
+	B := "45360"
+
+	for i := 0; i < b.N; i++ {
+		a, _ := strconv.Atoi(A)
+		b, _ := strconv.Atoi(B)
+
+		assignval = a + b
+	}
+}

--- a/cmd/_integration-tests/transport/http_benchmarks_test.go
+++ b/cmd/_integration-tests/transport/http_benchmarks_test.go
@@ -127,10 +127,9 @@ func BenchmarkAddition(b *testing.B) {
 		if err != nil {
 			b.Fatalf("httpclient returned error: %q", err)
 		}
-		if res != nil {
-			res.Body.Close()
-		}
-		assignval = res
+		ioutil.ReadAll(res.Body)
+		_ = res.Body.Close()
+		assignval = res.Body
 	}
 }
 

--- a/cmd/_integration-tests/transport/setup_test.go
+++ b/cmd/_integration-tests/transport/setup_test.go
@@ -102,5 +102,9 @@ func TestMain(m *testing.M) {
 	nonJSONHTTPServer := httptest.NewServer(bmux)
 	nonJSONHTTPAddr = nonJSONHTTPServer.URL
 
+	mux := setupSimpleServer()
+	benchServer := httptest.NewServer(mux)
+	benchAddr = benchServer.URL
+
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
This PR adds benchmarks for the HTTP pipeline of truss-generated services. Additionally, this PR adds those same benchmarks to the build pipeline so they'll always be run.

Please let me know if there are other areas or things which should be benchmarked, or if the way that I'm currently benchmarking things is incorrect.

-----

To run these benchmarks yourself, run the following command:

    cd $GOPATH/src/github.com/TuneLab/truss/cmd/_integration-tests/transport && make

I'm pasting the results of the benchmark here for posterities sake:
```
go test -run=XXX -bench=.
BenchmarkGetWithQueryClient-4             	   10000	    138193 ns/op
BenchmarkGetWithQueryClient_NoNetwork-4   	  200000	      8018 ns/op
BenchmarkClientEncoding-4                 	  300000	      4092 ns/op
BenchmarkAddition-4                       	20000000	        64.9 ns/op
PASS
```