### PR TITLE
Add Windows installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Otherwise [install from source.](https://github.com/google/protobuf)
 	make dependencies
 	make
 	```
+	On Windows, do the following instead:
+	```
+	go get -u -d github.com/TuneLab/truss
+	cd %GOPATH%/src/github.com/TuneLab/truss
+	wininstall.bat
+	```
 
 ## Usage
 

--- a/wininstall.bat
+++ b/wininstall.bat
@@ -21,6 +21,7 @@ FOR /F "tokens=* USEBACKQ" %%F IN (`%DATE_FMT_CMD%`) DO (
 )
 
 @ECHO ON
+go get github.com/pauln/go-datefmt
 go get github.com/golang/protobuf/protoc-gen-go
 go get github.com/golang/protobuf/proto
 go get github.com/jteeuwen/go-bindata/...

--- a/wininstall.bat
+++ b/wininstall.bat
@@ -1,0 +1,30 @@
+@ECHO OFF
+
+SET SHA_CMD="git rev-parse --short=10 HEAD"
+FOR /F "tokens=* USEBACKQ" %%F IN (`%SHA_CMD%`) DO (
+	SET SHA=%%F
+)
+
+SET HEAD_CMD="git rev-parse HEAD"
+FOR /F "tokens=* USEBACKQ" %%F IN (`%HEAD_CMD%`) DO (
+	SET HEAD_COMMIT=%%F
+)
+
+SET HEAD_DATE_CMD="git show -s --format=%%ct %HEAD_COMMIT%"
+FOR /F "tokens=* USEBACKQ" %%F IN (`%HEAD_DATE_CMD%`) DO (
+	SET GIT_COMMIT_EPOC=%%F
+)
+
+SET DATE_FMT_CMD="go-datefmt -ts %GIT_COMMIT_EPOC% -fmt UnixDate -utc"
+FOR /F "tokens=* USEBACKQ" %%F IN (`%DATE_FMT_CMD%`) DO (
+	SET HEAD_DATE=%%F
+)
+
+@ECHO ON
+go get github.com/golang/protobuf/protoc-gen-go
+go get github.com/golang/protobuf/proto
+go get github.com/jteeuwen/go-bindata/...
+go generate github.com/TuneLab/truss/gengokit/template
+go install github.com/TuneLab/truss/cmd/protoc-gen-truss-protocast
+go install -ldflags "-X 'main.Version=%SHA%' -X 'main.VersionDate=%HEAD_DATE%'" github.com/TuneLab/truss/cmd/truss
+@ECHO OFF


### PR DESCRIPTION
Although Truss will happily work under Windows, installing it is not a trivial process.  I've written a batch file which installs Truss by following the process which runs when calling `make dependencies; make`, and so far (tested on a couple of different Windows PCs) seems to reliably build and install Truss.

The main deviation from the Makefile-driven build process is that Windows has no native way to convert a Unix timestamp into the format used for the version date - so I wrote a super-quick, super-basic date conversion tool in Go ([pauln/go-datefmt](https://github.com/pauln/go-datefmt)) which the batch file installs and uses.