### PR TITLE
Fix bug reported in issue #202, comment causing panics in documentation generation

### DIFF
--- a/deftree/associate_comments.go
+++ b/deftree/associate_comments.go
@@ -266,7 +266,10 @@ func AssociateComments(dt Deftree, req *plugin.CodeGeneratorRequest) {
 					if err != nil {
 						log.Debugf("Couldn't place comment '%v' due to error traversing tree: %v", cleanStr(lead), err)
 					} else {
-						dt.SetComment(name_path, scrubComments(lead))
+						err = dt.SetComment(name_path, scrubComments(lead))
+						if err != nil && !strings.Contains(err.Error(), "cannot find node") {
+							log.Errorf("cannot set comment: %v", err)
+						}
 					}
 				}
 			}

--- a/deftree/associate_comments_test.go
+++ b/deftree/associate_comments_test.go
@@ -46,3 +46,43 @@ func TestCommentedEnum(t *testing.T) {
 		t.Fatalf("Comment found in Enum is not expected; got = %q, want = %q", got, want)
 	}
 }
+
+// Test to ensure that placing comments directly above a proto3 import functions correctly.
+func TestCommentedImport(t *testing.T) {
+	// Create our request, then assemble a basic deftree
+	defStr := `
+		// This comment should not cause any problems
+		syntax = "proto3";
+
+		// This comment should not cause any problems
+		
+		// This comment should not cause any problems
+		package general;
+
+		// This comment should not cause any problems
+		import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
+
+		// This comment should not cause any problems
+		message SumRequest {
+			int64 a = 1;
+			int64 b = 2;
+		}
+
+		service SumSvc {
+			rpc Sum(SumRequest) returns (SumRequest) {
+				option (google.api.http) = {
+					get: "/sum/{a}"
+				};
+			}
+		}
+	`
+	dt, err := NewFromString(defStr, gopath)
+	md := dt.(*MicroserviceDefinition)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if md == nil {
+		t.Fatalf("The returned Deftree is nil")
+	}
+}

--- a/deftree/deftree.go
+++ b/deftree/deftree.go
@@ -72,7 +72,7 @@ type Describable interface {
 // documentation on these Methods.
 type Deftree interface {
 	Describable
-	SetComment([]string, string)
+	SetComment([]string, string) error
 	String() string
 }
 
@@ -142,17 +142,20 @@ func (self *MicroserviceDefinition) GetByName(name string) Describable {
 // on the result of the last call, beginning with this MicroserviceDefinition.
 // Once the final Describable object is found, the `description` field of that
 // struct is set to `comment_body`.
-func (self *MicroserviceDefinition) SetComment(namepath []string, comment_body string) {
+//
+// If a node cannot be found with the provided namepath, returns an error.
+func (self *MicroserviceDefinition) SetComment(namepath []string, comment_body string) error {
 	var cur_node Describable
 	cur_node = self
 	for _, name := range namepath {
 		new_node := cur_node.GetByName(name)
 		if new_node == nil {
-			panic(fmt.Sprintf("New node is nil, namepath: '%v' cur_node: '%v'\n", namepath, cur_node))
+			return fmt.Errorf("cannot find node with name %q in namepath %q on cur_node %q", name, namepath, cur_node)
 		}
 		cur_node = new_node
 	}
 	cur_node.SetDescription(comment_body)
+	return nil
 }
 
 // String kicks off the recursive call to `describe` within the tree of


### PR DESCRIPTION
This PR implements a fix for the problem reported by @pauln in issue #202. The fix implemented here is the one I roughly outlined in a comment on that issue:

> ...it seems that `truss` is written with a bug in it such that if you attempt to associate a comment with something that this portion of the codebase doesn't care about or keep track of, then truss incorrectly panics instead of returning an error which can be handled.
> 
> IMO, the fix is to change [this function](https://github.com/TuneLab/truss/blob/096ba69249ea9c36208500413b665307c7431d00/deftree/deftree.go#L151) so that it returns an error which can be logged/handled/ignored as needed.

More specifically, I've changed that function to now return custom-typed errors, which are type-asserted by the consuming function to check whether they are of this type which can optionally be handled, and if they they are, then an error is logged.

Because this portion of the code (`deftree/`) is responsible for documentation generation, which is lower priority than code generation, I opted to only log an error instead of terminating program execution.