### PR TITLE
Proposal: Use jsonpb to (un)marshall messages to/from JSON

### DIFF
--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -17,6 +17,7 @@ import (
 	pb "github.com/TuneLab/truss/cmd/_integration-tests/transport/transportpermutations-service"
 	httpclient "github.com/TuneLab/truss/cmd/_integration-tests/transport/transportpermutations-service/svc/client/http"
 
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 )
 
@@ -606,7 +607,21 @@ func testHTTP(
 		t.Fatal(errors.Wrap(err, "cannot make http request"))
 	}
 
-	err = json.Unmarshal(respBytes, &resp)
+	switch v := resp.(type) {
+	case *pb.GetWithQueryResponse:
+		err = jsonpb.UnmarshalString(string(respBytes), v)
+	case *pb.GetWithRepeatedQueryResponse:
+		err = jsonpb.UnmarshalString(string(respBytes), v)
+	case *pb.GetWithEnumQueryResponse:
+		err = jsonpb.UnmarshalString(string(respBytes), v)
+	case *pb.PostWithNestedMessageBodyResponse:
+		err = jsonpb.UnmarshalString(string(respBytes), v)
+	case *pb.MetaResponse:
+		err = jsonpb.UnmarshalString(string(respBytes), v)
+	default:
+		t.Fatalf("Unknown response type: %T", v)
+	}
+
 	if err != nil {
 		t.Fatal(errors.Wrapf(err, "json error, got response: %q", string(respBytes)))
 	}

--- a/gengokit/httptransport/templates/client.go
+++ b/gengokit/httptransport/templates/client.go
@@ -90,6 +90,10 @@ import (
 	"strings"
 	"context"
 
+	{{ if len .HTTPHelper.Methods -}}
+		"github.com/golang/protobuf/jsonpb"
+	{{- end }}
+
 	"github.com/go-kit/kit/endpoint"
 	httptransport "github.com/go-kit/kit/transport/http"
 	"github.com/pkg/errors"
@@ -225,7 +229,7 @@ func contextValuesToHttpHeaders(keys []string) httptransport.RequestFunc {
 		}
 
 		var resp pb.{{GoName $method.ResponseType}}
-		if err = json.Unmarshal(buf, &resp); err != nil {
+		if err = jsonpb.UnmarshalString(string(buf), &resp); err != nil {
 			return nil, errorDecoder(buf)
 		}
 

--- a/gengokit/httptransport/templates/server.go
+++ b/gengokit/httptransport/templates/server.go
@@ -14,7 +14,11 @@ var ServerDecodeTemplate = `
 			return nil, errors.Wrapf(err, "cannot read body of http request")
 		}
 		if len(buf) > 0 {
-			if err = jsonpb.UnmarshalString(string(buf), &req); err != nil {
+			// AllowUnknownFields stops the unmarshaler from failing if the JSON contains unknown fields.
+			unmarshaller := jsonpb.Unmarshaler{
+				AllowUnknownFields: true,
+			}
+			if err = unmarshaller.Unmarshal(bytes.NewBuffer(buf), &req); err != nil {
 				const size = 8196
 				if len(buf) > size {
 					buf = buf[:size]

--- a/gengokit/httptransport/templates_test.go
+++ b/gengokit/httptransport/templates_test.go
@@ -173,7 +173,7 @@ func DecodeHTTPSumZeroRequest(_ context.Context, r *http.Request) (interface{}, 
 		return nil, errors.Wrapf(err, "cannot read body of http request")
 	}
 	if len(buf) > 0 {
-		if err = json.Unmarshal(buf, &req); err != nil {
+		if err = jsonpb.UnmarshalString(string(buf), &req); err != nil {
 			const size = 8196
 			if len(buf) > size {
 				buf = buf[:size]

--- a/gengokit/httptransport/templates_test.go
+++ b/gengokit/httptransport/templates_test.go
@@ -173,7 +173,11 @@ func DecodeHTTPSumZeroRequest(_ context.Context, r *http.Request) (interface{}, 
 		return nil, errors.Wrapf(err, "cannot read body of http request")
 	}
 	if len(buf) > 0 {
-		if err = jsonpb.UnmarshalString(string(buf), &req); err != nil {
+		// AllowUnknownFields stops the unmarshaler from failing if the JSON contains unknown fields.
+		unmarshaller := jsonpb.Unmarshaler{
+			AllowUnknownFields: true,
+		}
+		if err = unmarshaller.Unmarshal(bytes.NewBuffer(buf), &req); err != nil {
 			const size = 8196
 			if len(buf) > size {
 				buf = buf[:size]


### PR DESCRIPTION
The stdlib encoding/json package isn't able to (un)marshal some advanced protobuf features such as `oneof` fields.  [golang/protobuf/jsonpb](http://github.com/golang/protobuf/jsonpb) should be used instead, as it follows the [canonical proto3 JSON encoding](https://developers.google.com/protocol-buffers/docs/proto3#json) and therefore supports these features.

This change should allow `oneof` fields to be used, though the warning message added by #226 can probably be removed again (or degraded to debug level) as it (mostly) relates to the previous lack of support for `oneof` fields.