### PR TITLE
Add support for custom HTTP verbs

### DIFF
--- a/_example/echo.proto
+++ b/_example/echo.proto
@@ -14,32 +14,38 @@ service Echo {
   // Echo "echos" the incoming string
   rpc Echo (EchoRequest) returns (EchoResponse) {
     option (google.api.http) = {
-        // All fields (In) are query parameters of the http request unless otherwise specified
-        get: "/echo"
+      // All fields (In) are query parameters of the http request unless otherwise specified
+      get: "/echo"
 
-        additional_bindings {
-          // Trailing slashes are different routes
-          get: "/echo/"
-        }
-      };
+      additional_bindings {
+        // Trailing slashes are different routes
+        get: "/echo/"
+      }
+    };
   }
 
   // Louder "echos" the incoming string with `Loudness` additional exclamation marks
   rpc Louder (LouderRequest) returns (EchoResponse) {
     option (google.api.http) = {
+      custom {
+        kind: "HEAD"
         // Loudness is accepted in the http path
+        path: "/louder/{Loudness}"
+      }
+      additional_bindings {
         post: "/louder/{Loudness}"
         // All other fields (In) are located in the body of the http/json request
         body: "*"
-      };
+      }
+    };
   }
 
   // LouderGet is the same as Louder, but pulls fields other than Loudness (i.e. In) from query params instead of POST
   rpc LouderGet (LouderRequest) returns (EchoResponse) {
     option (google.api.http) = {
-        // Loudness is accepted in the http path
-        get: "/louder/{Loudness}"
-      };
+      // Loudness is accepted in the http path
+      get: "/louder/{Loudness}"
+    };
   }
 }
 

--- a/cmd/_integration-tests/cli/cli_test.go
+++ b/cmd/_integration-tests/cli/cli_test.go
@@ -189,6 +189,11 @@ func TestAdditionalBindings(t *testing.T) {
 	testEndToEnd("6-additional_bindings", "getadditional", t)
 }
 
+func TestCustomHTTPVerbs(t *testing.T) {
+	testEndToEnd("7-custom_http_verb", "getadditional", t)
+	testEndToEnd("7-custom_http_verb", "postadditional", t)
+}
+
 func testEndToEnd(defDir string, subcmd string, t *testing.T, trussOptions ...string) {
 	path := filepath.Join(basePath, defDir)
 	err := createTrussService(path)

--- a/cmd/_integration-tests/cli/test-service-definitions/7-custom_http_verb/custom_http_verb.proto
+++ b/cmd/_integration-tests/cli/test-service-definitions/7-custom_http_verb/custom_http_verb.proto
@@ -1,0 +1,77 @@
+syntax = "proto3";
+
+package custom_http_verb;
+
+import "github.com/TuneLab/truss/deftree/googlethirdparty/annotations.proto";
+
+service TEST {
+  rpc GetAdditional (BasicTypeRequest) returns (BasicTypeResponse) {
+    option (google.api.http) = {
+      custom {
+        kind: "CUSTOMGET"
+        path: "/1"
+      }
+
+      additional_bindings {
+        custom {
+          kind: "CUSTOMGET"
+          path: "/1/1"
+        }
+      }
+    };
+  }
+
+
+  rpc PostAdditional (BasicTypeRequest) returns (BasicTypeRequest) {
+    option (google.api.http) = {
+      custom {
+        kind: "CUSTOMPOST"
+        path: "/2"
+      }
+      body: "*"
+
+      additional_bindings {
+        custom {
+          kind: "CUSTOMPOST"
+          path: "/2/2"
+        }
+        body: "*"
+      }
+    };
+  }
+}
+
+message BasicTypeRequest {
+  double A = 1;
+  float B = 2;
+  int32 C = 3;
+  int64 D = 4;
+  uint32 E = 5;
+  uint64 F = 6;
+  sint32 G = 7;
+  sint64 H = 8;
+  fixed32 I = 9;
+  fixed64 J = 10;
+  sfixed32 K = 11;
+  bool L = 12;
+  string M = 13;
+  bytes N = 14;
+}
+
+message BasicTypeResponse {
+  double A = 1;
+  float B = 2;
+  int32 C = 3;
+  int64 D = 4;
+  uint32 E = 5;
+  uint64 F = 6;
+  sint32 G = 7;
+  sint64 H = 8;
+  fixed32 I = 9;
+  fixed64 J = 10;
+  sfixed32 K = 11;
+  bool L = 12;
+  string M = 13;
+  bytes N = 14;
+}
+

--- a/cmd/_integration-tests/transport/Makefile
+++ b/cmd/_integration-tests/transport/Makefile
@@ -29,7 +29,7 @@ test: setup
 	@echo -e '$(TRUSS_AGAIN_MSG)'
 	truss transport-test.proto
 	@echo -e '$(TEST_RUNNING_MSG)'
-	go test -run=$(match)-v
+	go test -run=$(match) -v
 	$(MAKE) clean
 
 bench: setup

--- a/cmd/_integration-tests/transport/handlers/handlers.go
+++ b/cmd/_integration-tests/transport/handlers/handlers.go
@@ -158,3 +158,11 @@ func (s transportpermutationsService) StatusCodeAndHeaders(ctx context.Context, 
 		"Test": []string{"A", "B"},
 	}}
 }
+
+// CustomVerb implements Service
+func (s transportpermutationsService) CustomVerb(ctx context.Context, in *pb.GetWithQueryRequest) (*pb.GetWithQueryResponse, error) {
+	response := pb.GetWithQueryResponse{
+		V: in.A + in.B,
+	}
+	return &response, nil
+}

--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -579,6 +579,43 @@ func TestNonJSONRequestBodyReturnsResponseWithStatusCode400(t *testing.T) {
 	}
 }
 
+// Manually test that we can make HTTP requests with a custom verb
+func TestCustomVerbRequest(t *testing.T) {
+	var resp pb.GetWithQueryResponse
+
+	var A, B int64
+	A = 12
+	B = 45360
+	expects := pb.GetWithQueryResponse{
+		V: A + B,
+	}
+
+	testHTTP(t, &resp, &expects, nil, "CUSTOMVERB", "customverb?%s=%d&%s=%d", "A", A, "B", B)
+}
+
+// Test that we can use the generated client to make requests to methods which
+// use custom verbs.
+func TestCustomVerbClient(t *testing.T) {
+	var req pb.GetWithQueryRequest
+	req.A = 12
+	req.B = 45360
+	want := req.A + req.B
+
+	svchttp, err := httpclient.New(httpAddr)
+	if err != nil {
+		t.Fatalf("failed to create httpclient: %q", err)
+	}
+
+	resp, err := svchttp.CustomVerb(context.Background(), &req)
+	if err != nil {
+		t.Fatalf("httpclient returned error: %q", err)
+	}
+
+	if resp.V != want {
+		t.Fatalf("Expect: %d, got %d", want, resp.V)
+	}
+}
+
 // Helpers
 
 // Generic way to test that making an HTTP request returns the expected data,

--- a/cmd/_integration-tests/transport/setup_test.go
+++ b/cmd/_integration-tests/transport/setup_test.go
@@ -39,6 +39,7 @@ func TestMain(m *testing.M) {
 	contentTypeTestE := svc.MakeContentTypeTestEndpoint(service)
 	StatusCodeAndNilHeadersE := svc.MakeStatusCodeAndNilHeadersEndpoint(service)
 	StatusCodeAndHeadersE := svc.MakeStatusCodeAndHeadersEndpoint(service)
+	CustomVerbE := svc.MakeCustomVerbEndpoint(service)
 
 	endpoints := svc.Endpoints{
 		GetWithQueryEndpoint:              getWithQueryE,
@@ -57,6 +58,7 @@ func TestMain(m *testing.M) {
 		ContentTypeTestEndpoint:           contentTypeTestE,
 		StatusCodeAndNilHeadersEndpoint:   StatusCodeAndNilHeadersE,
 		StatusCodeAndHeadersEndpoint:      StatusCodeAndHeadersE,
+		CustomVerbEndpoint:                CustomVerbE,
 	}
 
 	// http test server

--- a/cmd/_integration-tests/transport/transport-test.proto
+++ b/cmd/_integration-tests/transport/transport-test.proto
@@ -92,6 +92,14 @@ service TransportPermutations {
       get: "/status/code/and/headers"
     };
   }
+  rpc CustomVerb (GetWithQueryRequest) returns (GetWithQueryResponse) {
+    option (google.api.http) = {
+      custom {
+        kind: "CUSTOMVERB"
+        path: "/customverb"
+      }
+    };
+  }
 }
 
 message Empty {}

--- a/deftree/build_deftree.go
+++ b/deftree/build_deftree.go
@@ -403,6 +403,15 @@ func convertSvcparse(parsedSvc *svcparse.Service) (*ProtoService, error) {
 				}
 				b.Fields = append(b.Fields, f)
 			}
+			for _, pc := range pb.CustomHTTPPattern {
+				f := &BindingField{
+					Name:        pc.Name,
+					Description: scrubComments(pc.Description),
+					Kind:        pc.Kind,
+					Value:       pc.Value,
+				}
+				b.CustomHTTPPattern = append(b.CustomHTTPPattern, f)
+			}
 			m.HttpBindings = append(m.HttpBindings, b)
 		}
 		rv.Methods = append(rv.Methods, m)

--- a/deftree/contextualize.go
+++ b/deftree/contextualize.go
@@ -51,6 +51,16 @@ func contextualizeBinding(meth *ServiceMethod, binding *MethodHttpBinding) error
 
 // Get's the verb of binding. Currently doesn't support "custom" verbs.
 func getVerb(binding *MethodHttpBinding) (verb string, path string) {
+	if binding.CustomHTTPPattern != nil {
+		for _, field := range binding.CustomHTTPPattern {
+			if field.Kind == "kind" {
+				verb = field.Value
+			} else if field.Kind == "path" {
+				path = field.Value
+			}
+		}
+		return verb, path
+	}
 	for _, field := range binding.Fields {
 		switch field.Kind {
 		case "get", "put", "post", "delete", "patch":

--- a/deftree/deftree.go
+++ b/deftree/deftree.go
@@ -510,12 +510,13 @@ func (self *ServiceMethod) GetByName(name string) Describable {
 
 type MethodHttpBinding struct {
 	Describable
-	Name        string
-	Description string
-	Verb        string
-	Path        string
-	Fields      []*BindingField
-	Params      []*HttpParameter
+	Name              string
+	Description       string
+	Verb              string
+	Path              string
+	Fields            []*BindingField
+	CustomHTTPPattern []*BindingField
+	Params            []*HttpParameter
 }
 
 func (self *MethodHttpBinding) GetName() string {

--- a/deftree/svcparse/parser.go
+++ b/deftree/svcparse/parser.go
@@ -83,6 +83,8 @@ type Method struct {
 // HTTPBinding holds information extracted by the parser about each HTTP
 // binding within each method.
 type HTTPBinding struct {
+	// At this time, the way to provide a "description" of an HTTP binding is
+	// to write a comment directly above the "option" statement in an rpc.
 	Description string
 	Fields      []*Field
 	// CustomHTTPPattern contains the fields for a `custom` HTTP verb. It's
@@ -141,7 +143,7 @@ type HTTPBinding struct {
 // HTTP binding.
 type Field struct {
 	// Name acts as an 'alias' for the Field. Usually, it has the same value as
-	// "Kind", though there are no guaruntees that they'll be the same. Name
+	// "Kind", though there are no guarantees that they'll be the same. Name
 	// should never be used as part of "business logic" it is purely as a
 	// human-readable decorative field.
 	Name        string

--- a/svcdef/consolidate_http.go
+++ b/svcdef/consolidate_http.go
@@ -107,10 +107,22 @@ func assembleHTTPParams(svc *Service, httpsvc *svcparse.Service) error {
 	return nil
 }
 
-// getVerb returns the verb of a svcparse.HTTPBinding. If the binding does not
-// contain a field with a verb, returns two empty strings. Currently doesn't
-// support "custom" verbs.
+// getVerb returns the verb of a svcparse.HTTPBinding. The verb is found by
+// first checking if there's a 'customHTTPPattern' for a binding and using
+// that. If there's no custom verb defined, then we search through the defined
+// fields for a 'standard' field such as 'get', 'post', etc. If the binding
+// does not contain a field with a verb, returns two empty strings.
 func getVerb(binding *svcparse.HTTPBinding) (verb string, path string) {
+	if binding.CustomHTTPPattern != nil {
+		for _, field := range binding.CustomHTTPPattern {
+			if field.Kind == "kind" {
+				verb = field.Value
+			} else if field.Kind == "path" {
+				path = field.Value
+			}
+		}
+		return verb, path
+	}
 	for _, field := range binding.Fields {
 		switch field.Kind {
 		case "get", "put", "post", "delete", "patch":


### PR DESCRIPTION
Implements / Fixes #218 

## What does this add?

This PR adds support for using custom HTTP verbs in your routes for RPC methods. For example, you can now define a method as responding to `HEAD` requests, which in code would be like so:

```
service ExmplService {
  rpc ExmplMethod (RequestStrct) returns (ResponseStrct) {
    option (google.api.http) = {
      custom {                              ┐
        kind: "HEAD"                        │ This newly supported syntax is how
        path: "/foo/bar/{SomeFieldName}"    │ you define a custom HTTP verb.
      }                                     ┘
      // This 'body' field is optional
      body: "*"
    };
  }
}
```

You can define additional custom HTTP verbs using the `additional_bindings` syntax. For example:

```
service ExmplService {
  rpc ExmplMethod (RequestStrct) returns (ResponseStrct) {
    option (google.api.http) = {
      post: "/foo/bar/{SomeFieldName}"
      body: "*"
      
      additional_bindings {
        custom {
          kind: "FIRSTVERB"
          path: "/foo/bar/{SomeFieldName}"
        }
      }
      additional_bindings {
        custom {
          kind: "SECONDVERB"
          path: "/foo/bar/{SomeFieldName}"
        }
      }
    };
  }
}
```

## What does this *not* add?

This addition does not add the ability to differentiate between different HTTP verbs within a truss handler function. What does this mean? Let's take the service defined in the second example above, the one with multiple HTTP bindings for a single RPC method. The way truss works, you would get a single handler function in the generated `handlers/handlers.go` file, a handler function called `ExmplMethod`. Now, if a client makes a `POST` request to the `ExmplMethod` route, it'll be handled in the `ExmplMethod` function in `handlers/handlers.go`; the same things happen if you make a `FIRSTVERB` request to the `ExmplMethod` route, that is, the logic for how to respond to that route will be handled by the `ExmplMethod` function in `handlers/handlers.go`.

However, the function `ExmplMethod` in `handlers/handlers.go` *currently* does not have any way of knowing whether a request from a client was made using the `POST` verb or whether is was made using the `FIRSTVERB` verb. This is the remaining deficiency of this implementation, that currently the handler has no way of knowing which verb was used for a particular RPC. We welcome discussion on ways to expose this information to the handler in a clean and idiomatic way.

## Changelog

- [X] Expand the protobuf parser in `deftree/svcparse/` to correctly parse the `CustomHTTPPattern` syntax defined in `googlethirdparty/http.proto`
- [X] Modify the `svcparse/` package to leverage the new `CustomHTTPPattern` information from the protobuf parser
- [x] Update documentation generation
- [x] Add integration tests for verification of custom HTTP verb support

*Note: @adamryman has edited this PR text as it has become a WIP*