### PR TITLE
Bugfix: Fixes path generation when calling the `truss-protocast_out` plugin. 

### DIFF
--- a/truss/execprotoc/execprotoc.go
+++ b/truss/execprotoc/execprotoc.go
@@ -86,7 +86,7 @@ func getProtocOutput(protoPaths, gopath []string) ([]byte, error) {
 	}
 	defer os.RemoveAll(protocOutDir)
 
-	pluginCall := filepath.Join("--truss-protocast_out=", protocOutDir)
+	pluginCall := "--truss-protocast_out="+protocOutDir
 
 	err = protoc(protoPaths, gopath, pluginCall)
 	if err != nil {


### PR DESCRIPTION
Fixes path generation when calling the `truss-protocast_out` plugin. 
This hasn't been an issue prior to protoc 3.5.0. (Have also verified with 3.3+, 3.4+)

Essentially, filepath.Join shouldn't be used here as it produces an extra `/` which breaks file pathing.

### Log Dump:
```
cannot parse input definition proto files: cannot parse input files with protoc: cannot get output from protoc: protoc failed: protoc exec failed.
protoc output:

\Users\matth\AppData\Local\Temp\truss-294961478/: No such file or directory

protoc arguments:

[protoc --proto_path=C:\Users\matth\go\src\...\proto -IC:\Users\matth\go\src --truss-protocast_out=\C:\Users\matth\AppData\Local\Temp\truss-294961478 C:\Users\matth\go\src\...\proto\my.proto]

: exit status 1
```

Main thing here is that magical extra slash in which the plugin truncates the drive letter: 
```
--truss-protocast_out=\C:\Users\matth\AppData\Local\Temp\truss-294961478
```