### PR TITLE
Update http server to put "request-url" and "transport" in context.

### DIFF
--- a/gengokit/httptransport/templates/server.go
+++ b/gengokit/httptransport/templates/server.go
@@ -190,6 +190,11 @@ func headersToContext(ctx context.Context, r *http.Request) context.Context {
 		ctx = context.WithValue(ctx, strings.ToLower(k), r.Header.Get(k))
 	}
 
+	// Tune specific change.
+	// also add the request url
+	ctx = context.WithValue(ctx, "request-url", r.URL.Path)
+	ctx = context.WithValue(ctx, "transport", "HTTPJSON")
+
 	return ctx
 }
 `


### PR DESCRIPTION
Tune specific change. @leetune

Relates to commit `156d73c290b04b1ca0437f1340255ea5a1169860` https://github.com/TuneLab/truss/commit/156d73c290b04b1ca0437f1340255ea5a1169860

The client side code that does this same functionality will not be removed at this time for migration purposes.