### PR TITLE
remove protoc-gen-truss-protocast from windows install script.

### DIFF
--- a/wininstall.bat
+++ b/wininstall.bat
@@ -26,6 +26,5 @@ go get github.com/golang/protobuf/protoc-gen-go
 go get github.com/golang/protobuf/proto
 go get github.com/jteeuwen/go-bindata/...
 go generate github.com/tuneinc/truss/gengokit/template
-go install github.com/tuneinc/truss/cmd/protoc-gen-truss-protocast
 go install -ldflags "-X 'main.Version=%SHA%' -X 'main.VersionDate=%HEAD_DATE%'" github.com/tuneinc/truss/cmd/truss
 @ECHO OFF


### PR DESCRIPTION
Fixes windows installs