### PR TITLE
Fix example echo.proto import

### DIFF
--- a/_example/echo.proto
+++ b/_example/echo.proto
@@ -8,7 +8,7 @@ syntax = "proto3";
 // for `package echo;` truss will create the directory "echo-service".
 package echo;
 
-import "github.com/tuneinc/truss/deftree/googlethirdparty/annotations.proto";
+import "github.com/metaverse/truss/deftree/googlethirdparty/annotations.proto";
 
 service Echo {
   // Echo "echos" the incoming string


### PR DESCRIPTION
The import reference was still pointing to the tuneinc version of truss which caused generation to fail. After changing this to metaverse all seems well.