### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/cmd/_integration-tests/transport/handlers/handlers.go
+++ b/cmd/_integration-tests/transport/handlers/handlers.go
@@ -99,7 +99,7 @@ func (s transportpermutationsService) GetWithPathParams(ctx context.Context, in 
 	return &response, nil
 }
 
-// GetWithEnumQuery implements Service.
+// GetWithEnumPath implements Service.
 func (s transportpermutationsService) GetWithEnumPath(ctx context.Context, in *pb.GetWithEnumQueryRequest) (*pb.GetWithEnumQueryResponse, error) {
 	response := pb.GetWithEnumQueryResponse{
 		Out: in.In,

--- a/gengokit/handlers/middlewares.go
+++ b/gengokit/handlers/middlewares.go
@@ -12,7 +12,7 @@ import (
 // MiddlewaresPath is the path to the middleware gotemplate file.
 const MiddlewaresPath = "handlers/middlewares.gotemplate"
 
-// NewMiddleware returns a Renderable that renders the middlewares.go file.
+// NewMiddlewares returns a Renderable that renders the middlewares.go file.
 func NewMiddlewares() *Middlewares {
 	var m Middlewares
 


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?