### PR TITLE
Sort CLI flags returned by AllFlags() so generated code is stable.

### DIFF
--- a/gengokit/clientarggen/client_argument_generator.go
+++ b/gengokit/clientarggen/client_argument_generator.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -128,8 +129,14 @@ type ClientServiceArgs struct {
 // doing all this iteration in a template where it would be much less
 // understandable.
 func (c *ClientServiceArgs) AllFlags() string {
+	keys := []string{}
+	for k, _ := range c.MethArgs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
 	tmp := []string{}
-	for _, m := range c.MethArgs {
+	for _, k := range keys {
+		m := c.MethArgs[k]
 		for _, a := range m.Args {
 			tmp = append(tmp, a.FlagConvertFunc)
 		}


### PR DESCRIPTION
This is small change to add minimal sorting to AllFlags() so regenerating the code with no changes to the protobuf def'n does not generate differences due to random sorting of the lines declaring the CLI flag variables.  Also reduces the number of changes generated when small changes are made to the protobuf def'n.