### PR TITLE
use gogo's jsonpb

### DIFF
--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -17,7 +17,7 @@ import (
 	pb "github.com/metaverse/truss/cmd/_integration-tests/transport/proto"
 	httpclient "github.com/metaverse/truss/cmd/_integration-tests/transport/transportpermutations-service/svc/client/http"
 
-	"github.com/golang/protobuf/jsonpb"
+	"github.com/gogo/protobuf/jsonpb"
 	"github.com/pkg/errors"
 )
 

--- a/gengokit/httptransport/templates/client.go
+++ b/gengokit/httptransport/templates/client.go
@@ -91,7 +91,7 @@ import (
 	"context"
 
 	{{ if len .HTTPHelper.Methods -}}
-		"github.com/golang/protobuf/jsonpb"
+		"github.com/gogo/protobuf/jsonpb"
 	{{- end }}
 
 	"github.com/go-kit/kit/endpoint"

--- a/gengokit/httptransport/templates/server.go
+++ b/gengokit/httptransport/templates/server.go
@@ -71,8 +71,8 @@ import (
 	"strings"
 	"io"
 
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
 
 	"context"
 


### PR DESCRIPTION
Changes in https://github.com/metaverse/truss/pull/227 brought in jsonpb, but only occured to me after merge that they used the `golang/protobuf` package, but we switched to `gogo/protobuf` back in https://github.com/metaverse/truss/pull/262/commits/249f172d85815fa8449b3b90d74cb7d380a57204, so these changes are just getting everything on the same page. That said, I have no idea what the implications of not merging this are.