### PR TITLE
fix regression in how json is returned from the http path

### DIFF
--- a/gengokit/httptransport/httptransport_test.go
+++ b/gengokit/httptransport/httptransport_test.go
@@ -6,9 +6,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/metaverse/truss/gengokit/gentesthelper"
 	"github.com/metaverse/truss/svcdef"
-	"github.com/davecgh/go-spew/spew"
 )
 
 var (
@@ -33,6 +33,7 @@ func TestNewMethod(t *testing.T) {
 		message SumRequest {
 			int64 a = 1;
 			int64 b = 2;
+			int64 orig_name = 3;
 		}
 
 		message SumReply {
@@ -82,6 +83,19 @@ func TestNewMethod(t *testing.T) {
 				ConvertFunc:                "BSum, err := strconv.ParseInt(BSumStr, 10, 64)",
 				ConvertFuncNeedsErrorCheck: true,
 				TypeConversion:             "BSum",
+				IsBaseType:                 true,
+			},
+			&Field{
+				Name:                       "OrigName",
+				QueryParamName:             "orig_name",
+				CamelName:                  "OrigName",
+				LowCamelName:               "origName",
+				LocalName:                  "OrigNameSum",
+				Location:                   "query",
+				GoType:                     "int64",
+				ConvertFunc:                "OrigNameSum, err := strconv.ParseInt(OrigNameSumStr, 10, 64)",
+				ConvertFuncNeedsErrorCheck: true,
+				TypeConversion:             "OrigNameSum",
 				IsBaseType:                 true,
 			},
 		},

--- a/gengokit/httptransport/templates/server.go
+++ b/gengokit/httptransport/templates/server.go
@@ -182,7 +182,8 @@ func (h httpError) Headers() http.Header {
 func EncodeHTTPGenericResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
 	marshaller := jsonpb.Marshaler{
 		EnumsAsInts:  true,
-		EmitDefaults: true,
+		EmitDefaults: false,
+		OrigName: true,
 	}
 
 	return marshaller.Marshal(w, response.(proto.Message))


### PR DESCRIPTION
after bringing in some recent changes to use jsonpb, we introduced an accidental regression where the protobuf names stopped being returned as defined in the proto. Truss had changed in place to set the json tags to the correct value, but jsonpb doesnt seem to use those and goes by the protobuf mappings themselves