### PR TITLE
obviously the enums should be strings

### DIFF
--- a/gengokit/httptransport/templates/server.go
+++ b/gengokit/httptransport/templates/server.go
@@ -181,7 +181,6 @@ func (h httpError) Headers() http.Header {
 // the response as JSON to the response writer. Primarily useful in a server.
 func EncodeHTTPGenericResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
 	marshaller := jsonpb.Marshaler{
-		EnumsAsInts:  true,
 		EmitDefaults: false,
 		OrigName: true,
 	}


### PR DESCRIPTION
this got overlooked from the orginal jsonpb behavior since submitter was trying to maintain behavior, but strings is way better

before
```
$ curl -X POST localhost:5050/rack -d { "env": "prod" }
{"env":1"}
```

now
```
$ curl -X POST localhost:5050/rack -d { "env": "prod" }
{"env":"prod"}
```