### PR TITLE
Add paths=source_relative option to restore placement of output files.

### DIFF
--- a/truss/execprotoc/execprotoc.go
+++ b/truss/execprotoc/execprotoc.go
@@ -23,7 +23,7 @@ func GeneratePBDotGo(protoPaths, gopath []string, outDir string) error {
 		"Mgoogle/protobuf/struct.proto=github.com/gogo/protobuf/types," +
 		"Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types," +
 		"Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types," +
-		"plugins=grpc:" + outDir
+		"paths=source_relative,plugins=grpc:" + outDir
 
 	_, err := exec.LookPath("protoc-gen-gogo")
 	if err != nil {


### PR DESCRIPTION
I'll admit that I'm a little confused, but I _think_ that an update to an underlying dependency changed the default behavior about into which directory generated `*.pb.go` files get written.

This small change made my automation start working as it used to, even though I failed at finding documentation about this apparent change in behavior.

(If anybody has an idea what might have caused this change where generated `*.pb.go` files get written into a deep subdirectory of the specified output directory, a pointer to it would be appreciated.)