### PR TITLE
show actual error when jsonpb unmarshaling fails

### DIFF
--- a/gengokit/httptransport/templates/server.go
+++ b/gengokit/httptransport/templates/server.go
@@ -24,7 +24,7 @@ var ServerDecodeTemplate = `
 				if len(buf) > size {
 					buf = buf[:size]
 				}
-				return nil, httpError{fmt.Errorf("request body '%s': cannot parse non-json request body", buf),
+				return nil, httpError{errors.Wrapf(err, "request body '%s': cannot parse non-json request body", buf),
 					http.StatusBadRequest,
 					nil,
 				}

--- a/gengokit/httptransport/templates_test.go
+++ b/gengokit/httptransport/templates_test.go
@@ -173,7 +173,7 @@ func DecodeHTTPSumZeroRequest(_ context.Context, r *http.Request) (interface{}, 
 			if len(buf) > size {
 				buf = buf[:size]
 			}
-			return nil, httpError{fmt.Errorf("request body '%s': cannot parse non-json request body", buf),
+			return nil, httpError{errors.Wrapf(err, "request body '%s': cannot parse non-json request body", buf),
 				http.StatusBadRequest,
 				nil,
 			}

--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,16 @@ go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/go-kit/kit v0.9.0 // indirect
+	github.com/go-kit/kit v0.9.0
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.1
-	github.com/gorilla/mux v1.7.3 // indirect
-	github.com/moul/http2curl v1.0.0 // indirect
+	github.com/gorilla/mux v1.7.3
+	github.com/moul/http2curl v1.0.0
 	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.2.2
 	golang.org/x/tools v0.0.0-20191018190819-0bbdbb2ef609
-	google.golang.org/grpc v1.24.0 // indirect
+	google.golang.org/grpc v1.24.0
 )


### PR DESCRIPTION
This didnt really matter before we started using jsonpb, since failing to part JSON was pretty straightforward to debug. Now that we use jsonpb however more complex type-aware unmarshaling occurs. For example to unmarshal into a google.protobuf.Timestamp you need to use RFC3339Nano, and messing up the format yield an unuseful error message, so useless in fact that its hard to know its actually a value you messed up and it has nothing to do with your json...