### PR TITLE
Remove leading bracket on badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Truss [![Build Status](https://github.com/metaverse/truss/workflows/Go/badge.svg?branch=master)
+# Truss ![Build Status](https://github.com/metaverse/truss/workflows/Go/badge.svg?branch=master)
 
 Truss handles the painful parts of services, freeing you to focus on the
 business logic.


### PR DESCRIPTION
I missed this leading bracket when looking at the rich diff.

My mistake.