### PR TITLE
Add http transport tests for repeated query params

### DIFF
--- a/cmd/_integration-tests/transport/handlers/handlers.go
+++ b/cmd/_integration-tests/transport/handlers/handlers.go
@@ -49,6 +49,20 @@ func (s transportpermutationsService) GetWithRepeatedQuery(ctx context.Context, 
 	return &response, nil
 }
 
+func (s transportpermutationsService) GetWithRepeatedStringQuery(ctx context.Context, in *pb.GetWithRepeatedStringQueryRequest) (*pb.GetWithRepeatedStringQueryResponse, error) {
+	var out string
+
+	for _, v := range in.A {
+		out = out + v
+	}
+
+	response := pb.GetWithRepeatedStringQueryResponse{
+		V: out,
+	}
+
+	return &response, nil
+}
+
 // GetWithEnumQuery implements Service.
 func (s transportpermutationsService) GetWithEnumQuery(ctx context.Context, in *pb.GetWithEnumQueryRequest) (*pb.GetWithEnumQueryResponse, error) {
 	response := pb.GetWithEnumQueryResponse{

--- a/cmd/_integration-tests/transport/http_test.go
+++ b/cmd/_integration-tests/transport/http_test.go
@@ -99,17 +99,85 @@ func TestGetWithRepeatedQueryRequest(t *testing.T) {
 		V: A[0] + A[1],
 	}
 
-	err := testHTTP(t, &resp, &expects, nil, "GET", "getwithrepeatedquery?%s=[%d,%d]", "A", A[0], A[1])
+	var err error
+
+	err = testHTTP(t, &resp, &expects, nil, "GET", "getwithrepeatedquery?%s=[%d,%d]", "A", A[0], A[1])
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "cannot make http request"))
 	}
+
 	// csv style
 	err = testHTTP(t, &resp, &expects, nil, "GET", "getwithrepeatedquery?%s=%d,%d", "A", A[0], A[1])
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "cannot make http request"))
 	}
 	// multi / golang style
-	//err := testHTTP(nil, "GET", "getwithrepeatedquery?%s=%d&%s=%d]", "A", A[0], "A", A[1])
+	// err = testHTTP(t, &resp, &expects, nil, "GET", "getwithrepeatedquery?%s=%d&%s=%d", "A", A[0], "A", A[1])
+	// if err != nil {
+	// 	t.Fatal(errors.Wrap(err, "cannot make http request"))
+	// }
+}
+
+func TestGetWithRepeatedStringQueryClient(t *testing.T) {
+	var req pb.GetWithRepeatedStringQueryRequest
+	req.A = []string{"Hello", "truss"}
+	want := req.A[0] + req.A[1]
+
+	svchttp, err := httpclient.New(httpAddr)
+	if err != nil {
+		t.Fatalf("failed to create httpclient: %q", err)
+	}
+
+	resp, err := svchttp.GetWithRepeatedStringQuery(context.Background(), &req)
+	if err != nil {
+		t.Fatalf("httpclient returned error: %q", err)
+	}
+
+	if resp.V != want {
+		t.Fatalf("Expect: %s, got %s", want, resp.V)
+	}
+}
+
+func TestGetWithRepeatedStringQueryRequest(t *testing.T) {
+	resp := pb.GetWithRepeatedStringQueryResponse{}
+
+	var A []string
+	A = []string{"Hello", "truss"}
+	expects := pb.GetWithRepeatedStringQueryResponse{
+		V: A[0] + A[1],
+	}
+
+	var err error
+
+	err = testHTTP(t, &resp, &expects, nil, "GET", "getwithrepeatedstringquery?%s=[\"%s\",\"%s\"]", "A", A[0], A[1])
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "cannot make http request"))
+	}
+
+	// csv style
+	err = testHTTP(t, &resp, &expects, nil, "GET", "getwithrepeatedstringquery?%s=\"%s\",\"%s\"", "A", A[0], A[1])
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "cannot make http request"))
+	}
+
+	// default array, no quotes
+	// err = testHTTP(t, &resp, &expects, nil, "GET", "getwithrepeatedstringquery?%s=[%s,%s]", "A", A[0], A[1])
+	// if err != nil {
+	//	t.Fatal(errors.Wrap(err, "cannot make http request"))
+	// }
+
+	// csv style, no quotes
+	// err = testHTTP(t, &resp, &expects, nil, "GET", "getwithrepeatedstringquery?%s=[%s,%s]", "A", A[0], A[1])
+	// if err != nil {
+	//	t.Fatal(errors.Wrap(err, "cannot make http request"))
+	// }
+
+	// multi / golang style
+	// err = testHTTP(t, &resp, &expects, nil, "GET", "getwithrepeatedstringquery?%s=%s&%s=%s", "A", A[0], "A", A[1])
+	// if err != nil {
+	//	t.Fatal(errors.Wrap(err, "cannot make http request"))
+	// }
+
 }
 
 func TestGetWithEnumQueryClient(t *testing.T) {
@@ -747,6 +815,8 @@ func testHTTP(
 	case *pb.GetWithQueryResponse:
 		err = jsonpb.UnmarshalString(string(respBytes), v)
 	case *pb.GetWithRepeatedQueryResponse:
+		err = jsonpb.UnmarshalString(string(respBytes), v)
+	case *pb.GetWithRepeatedStringQueryResponse:
 		err = jsonpb.UnmarshalString(string(respBytes), v)
 	case *pb.GetWithEnumQueryResponse:
 		err = jsonpb.UnmarshalString(string(respBytes), v)

--- a/cmd/_integration-tests/transport/proto/transport-test.proto
+++ b/cmd/_integration-tests/transport/proto/transport-test.proto
@@ -15,6 +15,11 @@ service TransportPermutations {
       get: "/getwithrepeatedquery"
     };
   }
+  rpc GetWithRepeatedStringQuery (GetWithRepeatedStringQueryRequest) returns (GetWithRepeatedStringQueryResponse) {
+    option (google.api.http) = {
+      get: "/getwithrepeatedstringquery"
+    };
+  }
   rpc GetWithEnumQuery (GetWithEnumQueryRequest) returns (GetWithEnumQueryResponse) {
     option (google.api.http) = {
       get: "/getwithenumquery"
@@ -124,6 +129,14 @@ message GetWithRepeatedQueryRequest {
 
 message GetWithRepeatedQueryResponse {
   int64 V = 1;
+}
+
+message GetWithRepeatedStringQueryRequest {
+  repeated string A = 1;
+}
+
+message GetWithRepeatedStringQueryResponse {
+  string V = 1;
 }
 
 enum TestStatus {

--- a/cmd/_integration-tests/transport/setup_test.go
+++ b/cmd/_integration-tests/transport/setup_test.go
@@ -25,6 +25,7 @@ func TestMain(m *testing.M) {
 	// Endpoint domain.
 	getWithQueryE := svc.MakeGetWithQueryEndpoint(service)
 	getWithRepeatedQueryE := svc.MakeGetWithRepeatedQueryEndpoint(service)
+	getWithRepeatedStringQueryE := svc.MakeGetWithRepeatedStringQueryEndpoint(service)
 	getWithEnumQueryE := svc.MakeGetWithEnumQueryEndpoint(service)
 	postWithNestedMessageBodyE := svc.MakePostWithNestedMessageBodyEndpoint(service)
 	ctxToCtxE := svc.MakeCtxToCtxEndpoint(service)
@@ -43,24 +44,25 @@ func TestMain(m *testing.M) {
 	CustomVerbE := svc.MakeCustomVerbEndpoint(service)
 
 	endpoints := svc.Endpoints{
-		GetWithQueryEndpoint:              getWithQueryE,
-		GetWithRepeatedQueryEndpoint:      getWithRepeatedQueryE,
-		GetWithEnumQueryEndpoint:          getWithEnumQueryE,
-		PostWithNestedMessageBodyEndpoint: postWithNestedMessageBodyE,
-		CtxToCtxEndpoint:                  ctxToCtxE,
-		GetWithCapsPathEndpoint:           getWithCapsPathE,
-		GetWithPathParamsEndpoint:         getWithPathParamsE,
-		GetWithEnumPathEndpoint:           getWithEnumPathE,
-		GetWithOneofQueryEndpoint:         getWithOneofQueryE,
-		EchoOddNamesEndpoint:              echoOddNamesE,
-		ErrorRPCEndpoint:                  errorRPCE,
-		ErrorRPCNonJSONEndpoint:           errorRPCNonJSONE,
-		ErrorRPCNonJSONLongEndpoint:       errorRPCNonJSONLongE,
-		X2AOddRPCNameEndpoint:             X2AOddRPCNameE,
-		ContentTypeTestEndpoint:           contentTypeTestE,
-		StatusCodeAndNilHeadersEndpoint:   StatusCodeAndNilHeadersE,
-		StatusCodeAndHeadersEndpoint:      StatusCodeAndHeadersE,
-		CustomVerbEndpoint:                CustomVerbE,
+		GetWithQueryEndpoint:               getWithQueryE,
+		GetWithRepeatedQueryEndpoint:       getWithRepeatedQueryE,
+		GetWithRepeatedStringQueryEndpoint: getWithRepeatedStringQueryE,
+		GetWithEnumQueryEndpoint:           getWithEnumQueryE,
+		PostWithNestedMessageBodyEndpoint:  postWithNestedMessageBodyE,
+		CtxToCtxEndpoint:                   ctxToCtxE,
+		GetWithCapsPathEndpoint:            getWithCapsPathE,
+		GetWithPathParamsEndpoint:          getWithPathParamsE,
+		GetWithEnumPathEndpoint:            getWithEnumPathE,
+		GetWithOneofQueryEndpoint:          getWithOneofQueryE,
+		EchoOddNamesEndpoint:               echoOddNamesE,
+		ErrorRPCEndpoint:                   errorRPCE,
+		ErrorRPCNonJSONEndpoint:            errorRPCNonJSONE,
+		ErrorRPCNonJSONLongEndpoint:        errorRPCNonJSONLongE,
+		X2AOddRPCNameEndpoint:              X2AOddRPCNameE,
+		ContentTypeTestEndpoint:            contentTypeTestE,
+		StatusCodeAndNilHeadersEndpoint:    StatusCodeAndNilHeadersE,
+		StatusCodeAndHeadersEndpoint:       StatusCodeAndHeadersE,
+		CustomVerbEndpoint:                 CustomVerbE,
 	}
 
 	// http test server


### PR DESCRIPTION
Also add commented out tests for possible functionality.

This PR in response to #304, which changes how repeated strings are decoded in query parameters.

This PR adds http transport tests addressing repeated strings in query parameters.