### PR TITLE
fix: use consistent datetime format in version output

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,7 +73,7 @@ builds:
     env:
       - CGO_ENABLED=0
     main: cmd/truss/main.go
-    ldflags: -s -w -X main.version={{.Version}} -X main.date={{.Date}}
+    ldflags: -s -w -X main.version={{.Version}} -X main.date={{.CommitDate}}
     binary: truss
 
 archives:

--- a/commit_date.sh
+++ b/commit_date.sh
@@ -13,10 +13,10 @@ git_commit_epoc="$(git show -s --format=%ct $head_commit)"
 # bsd date does not have `--version`
 if [[ "$(date --version 2>/dev/null 1>/dev/null; echo $?)" -eq "1" ]]; then
 	# bsd date
-	commit_date=$(date -r $git_commit_epoc -u)
+	commit_date=$(date -r $git_commit_epoc -u +"%Y-%m-%dT%H:%M:%SZ")
 else
 	# gnu date
-	commit_date=$(date --date="@$git_commit_epoc" -u)
+	commit_date=$(date --date="@$git_commit_epoc" -u +"%Y-%m-%dT%H:%M:%SZ")
 fi
 
 echo $commit_date


### PR DESCRIPTION
also fixes goreleaser to use the commit date, which should be formatted as UTC rfc3999 per https://goreleaser.com/customization/templates/