### PR TITLE
Support gRPC transcoding syntax with '.=*' in path template

### DIFF
--- a/gengokit/httptransport/embeddable_funcs_test.go
+++ b/gengokit/httptransport/embeddable_funcs_test.go
@@ -1,0 +1,69 @@
+package httptransport
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEncodePathParams(t *testing.T) {
+	tests := []struct {
+		name string
+		vars map[string]string
+		want map[string]string
+	}{
+		{
+			name: "simple",
+			vars: map[string]string{
+				"parent": "shelves/shelf1",
+			},
+			want: map[string]string{
+				"parent": "shelves/shelf1",
+			},
+		},
+		{
+			name: "dot notation - single value",
+			vars: map[string]string{
+				"book.name": "shelves/shelf1/books/book1",
+			},
+			want: map[string]string{
+				"book": `{"name":"shelves/shelf1/books/book1"}`,
+			},
+		},
+		{
+			name: "dot notation - multiple values",
+			vars: map[string]string{
+				"book.name":    "shelves/shelf1/books/book1",
+				"book.version": "v1",
+			},
+			want: map[string]string{
+				"book": `{"name":"shelves/shelf1/books/book1","version":"v1"}`,
+			},
+		},
+		{
+			name: "dot notation - multiple levels",
+			vars: map[string]string{
+				"book.version.name": "versions/v1",
+			},
+			want: map[string]string{
+				"book": `{"version":{"name":"versions/v1"}}`,
+			},
+		},
+		{
+			name: "dot notation - multiple values in multiple levels",
+			vars: map[string]string{
+				"book.name":         "shelves/shelf1/books/book1",
+				"book.version.name": "versions/v1",
+			},
+			want: map[string]string{
+				"book": `{"name":"shelves/shelf1/books/book1","version":{"name":"versions/v1"}}`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := encodePathParams(tt.vars); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("encodePathParams() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/gengokit/httptransport/httptransport_test.go
+++ b/gengokit/httptransport/httptransport_test.go
@@ -251,6 +251,15 @@ func TestBinding_PathSections(t *testing.T) {
 				`"books"`,
 			},
 		},
+		{
+			name:         "dot notation",
+			pathTemplate: `/v1/{book.name:shelves/[^/]+/books/[^/]+}`,
+			want: []string{
+				`""`,
+				`"v1"`,
+				"fmt.Sprint(req.Book.Name)",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/gengokit/httptransport/templates/server.go
+++ b/gengokit/httptransport/templates/server.go
@@ -31,7 +31,7 @@ var ServerDecodeTemplate = `
 			}
 		}
 
-		pathParams := mux.Vars(r)
+		pathParams := encodePathParams(mux.Vars(r))
 		_ = pathParams
 
 		queryParams := r.URL.Query()

--- a/gengokit/httptransport/templates_test.go
+++ b/gengokit/httptransport/templates_test.go
@@ -180,7 +180,7 @@ func DecodeHTTPSumZeroRequest(_ context.Context, r *http.Request) (interface{}, 
 		}
 	}
 
-	pathParams := mux.Vars(r)
+	pathParams := encodePathParams(mux.Vars(r))
 	_ = pathParams
 
 	queryParams := r.URL.Query()

--- a/gengokit/template/template.go
+++ b/gengokit/template/template.go
@@ -425,31 +425,31 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"cmd": &bintree{nil, map[string]*bintree{
-		"NAME": &bintree{nil, map[string]*bintree{
-			"main.gotemplate": &bintree{cmdNameMainGotemplate, map[string]*bintree{}},
+	"cmd": {nil, map[string]*bintree{
+		"NAME": {nil, map[string]*bintree{
+			"main.gotemplate": {cmdNameMainGotemplate, map[string]*bintree{}},
 		}},
 	}},
-	"handlers": &bintree{nil, map[string]*bintree{
-		"handlers.gotemplate":    &bintree{handlersHandlersGotemplate, map[string]*bintree{}},
-		"hooks.gotemplate":       &bintree{handlersHooksGotemplate, map[string]*bintree{}},
-		"middlewares.gotemplate": &bintree{handlersMiddlewaresGotemplate, map[string]*bintree{}},
+	"handlers": {nil, map[string]*bintree{
+		"handlers.gotemplate": {handlersHandlersGotemplate, map[string]*bintree{}},
+		"hooks.gotemplate": {handlersHooksGotemplate, map[string]*bintree{}},
+		"middlewares.gotemplate": {handlersMiddlewaresGotemplate, map[string]*bintree{}},
 	}},
-	"svc": &bintree{nil, map[string]*bintree{
-		"client": &bintree{nil, map[string]*bintree{
-			"grpc": &bintree{nil, map[string]*bintree{
-				"client.gotemplate": &bintree{svcClientGrpcClientGotemplate, map[string]*bintree{}},
+	"svc": {nil, map[string]*bintree{
+		"client": {nil, map[string]*bintree{
+			"grpc": {nil, map[string]*bintree{
+				"client.gotemplate": {svcClientGrpcClientGotemplate, map[string]*bintree{}},
 			}},
-			"http": &bintree{nil, map[string]*bintree{
-				"client.gotemplate": &bintree{svcClientHttpClientGotemplate, map[string]*bintree{}},
+			"http": {nil, map[string]*bintree{
+				"client.gotemplate": {svcClientHttpClientGotemplate, map[string]*bintree{}},
 			}},
 		}},
-		"endpoints.gotemplate": &bintree{svcEndpointsGotemplate, map[string]*bintree{}},
-		"server": &bintree{nil, map[string]*bintree{
-			"run.gotemplate": &bintree{svcServerRunGotemplate, map[string]*bintree{}},
+		"endpoints.gotemplate": {svcEndpointsGotemplate, map[string]*bintree{}},
+		"server": {nil, map[string]*bintree{
+			"run.gotemplate": {svcServerRunGotemplate, map[string]*bintree{}},
 		}},
-		"transport_grpc.gotemplate": &bintree{svcTransport_grpcGotemplate, map[string]*bintree{}},
-		"transport_http.gotemplate": &bintree{svcTransport_httpGotemplate, map[string]*bintree{}},
+		"transport_grpc.gotemplate": {svcTransport_grpcGotemplate, map[string]*bintree{}},
+		"transport_http.gotemplate": {svcTransport_httpGotemplate, map[string]*bintree{}},
 	}},
 }}
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/gogo/protobuf v1.2.2-0.20190601103108-21df5aa0e680
+	github.com/kevinburke/go-bindata v3.22.0+incompatible // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gogo/protobuf v1.2.2-0.20190601103108-21df5aa0e680 h1:C0sYRtvp5PUPDdevTvhGWbyiRrLM1ci+tHfyJymCNzM=
 github.com/gogo/protobuf v1.2.2-0.20190601103108-21df5aa0e680/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/kevinburke/go-bindata v3.22.0+incompatible h1:/JmqEhIWQ7GRScV0WjX/0tqBrC5D21ALg0H0U/KZ/ts=
+github.com/kevinburke/go-bindata v3.22.0+incompatible/go.mod h1:/pEEZ72flUW2p0yi30bslSp9YqD9pysLxunQDdb2CPM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/svcdef/consolidate_http.go
+++ b/svcdef/consolidate_http.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
 	gogen "github.com/gogo/protobuf/protoc-gen-gogo/generator"
 
@@ -164,11 +164,10 @@ func paramLocation(field *Field, binding *svcparse.HTTPBinding) string {
 func getPathParams(binding *svcparse.HTTPBinding) []string {
 	_, path := getVerb(binding)
 	findParams := regexp.MustCompile("{(.*?)}")
-	removeBraces := regexp.MustCompile("{|}")
 	params := findParams.FindAllString(path, -1)
 	rv := []string{}
 	for _, p := range params {
-		rv = append(rv, removeBraces.ReplaceAllString(p, ""))
+		rv = append(rv, strings.Split(p[1:len(p)-1], "=")[0])
 	}
 	return rv
 }

--- a/svcdef/consolidate_http_test.go
+++ b/svcdef/consolidate_http_test.go
@@ -10,21 +10,36 @@ import (
 )
 
 func TestGetPathParams(t *testing.T) {
-	binding := &svcparse.HTTPBinding{
-		Fields: []*svcparse.Field{
-			&svcparse.Field{
-				Kind:  "get",
-				Value: `"/{a}/{b}"`,
-			},
+	tests := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{
+			name:  "basic",
+			value: `"/{a}/{b}"`,
+			want:  []string{"a", "b"},
+		},
+		{
+			name:  "variable with path segments",
+			value: `"/v1/{parent=shelves/*}/books"`,
+			want:  []string{"parent"},
 		},
 	}
-	params := getPathParams(binding)
-	if len(params) != 2 {
-		t.Fatalf("Params (%v) is length '%v', expected length 2", params, len(params))
-	}
-	expected := []string{"a", "b"}
-	if !reflect.DeepEqual(params, expected) {
-		t.Fatalf("Params is %v, expected %v", params, expected)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			binding := &svcparse.HTTPBinding{
+				Fields: []*svcparse.Field{
+					{
+						Kind:  "get",
+						Value: tt.value,
+					},
+				},
+			}
+			if got := getPathParams(binding); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getPathParams() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The transcoding syntax of the path templates is specified here: https://github.com/googleapis/googleapis/blob/master/google/api/http.proto#L224

Here are some usage examples:
https://cloud.google.com/apis/design/standard_methods#update

```proto
rpc UpdateBook(UpdateBookRequest) returns (Book) {
  option (google.api.http) = {
    patch: "/v1/{book.name=shelves/*/books/*}"
    body: "book"
  };
}

message Book {
  string name = 1;
  string title = 2;
}

message UpdateBookRequest {
  Book book = 1;
}
```