### PR TITLE
fix: correctly map request body field by name

### DIFF
--- a/gengokit/httptransport/httptransport.go
+++ b/gengokit/httptransport/httptransport.go
@@ -156,6 +156,10 @@ func NewBinding(i int, meth *svcdef.ServiceMethod) *Binding {
 		newField.IsEnum = field.Type.Enum != nil
 		newField.ConvertFunc, newField.ConvertFuncNeedsErrorCheck = createDecodeConvertFunc(newField)
 		newField.TypeConversion = createDecodeTypeConversion(newField)
+		if newField.Location == "body_root" {
+			newField.Location = "body"
+			nBinding.RequestRootField = &newField
+		}
 
 		nBinding.Fields = append(nBinding.Fields, &newField)
 

--- a/gengokit/httptransport/types.go
+++ b/gengokit/httptransport/types.go
@@ -28,6 +28,7 @@ type Binding struct {
 	Verb        string
 	Fields      []*Field
 	OneofFields []*OneofField
+	RequestRootField *Field
 	// A pointer back to the parent method of this binding. Used within some
 	// binding methods
 	Parent *Method

--- a/svcdef/consolidate_http.go
+++ b/svcdef/consolidate_http.go
@@ -148,11 +148,11 @@ func paramLocation(field *Field, binding *svcparse.HTTPBinding) string {
 			if optField.Value == "*" {
 				return "body"
 			} else if optField.Value == field.Name {
-				return "body"
+				return "body_root"
 				// Have to CamelCase the fields from the protobuf file, as they may
 				// be lowercase while the name from the Go file will be CamelCased.
 			} else if gogen.CamelCase(strings.Split(optField.Value, ".")[0]) == field.Name {
-				return "body"
+				return "body_root"
 			}
 		}
 	}

--- a/svcdef/consolidate_http_test.go
+++ b/svcdef/consolidate_http_test.go
@@ -124,7 +124,7 @@ service Map {
 		Name     string
 		Location string
 	}{
-		{"A", "body"},
+		{"A", "body_root"},
 		{"AA", "query"},
 		{"C", "query"},
 		{"MapField", "query"},


### PR DESCRIPTION
Hi, I've tried to fix issue #325, this PR should do it.

I've changed the field path to `body_root` if the current field is mapped by name, which allows setting RequestRootField in `gengokit/http_transport.go`, which is, in turn, checked in the template to select in which variable body will be deserialized.
This fixes the issue in my cases, although maybe it should probably be worth hiding this fix under some option, at least for a few releases to keep backward compatibility.