### PR TITLE
fix bug: package "io" is not used

### DIFF
--- a/gengokit/httptransport/templates/client.go
+++ b/gengokit/httptransport/templates/client.go
@@ -140,6 +140,7 @@ var (
 	_ = fmt.Sprint
 	_ = bytes.Compare
 	_ = ioutil.NopCloser
+	_ = io.EOF
 )
 
 // New returns a service backed by an HTTP server living at the remote


### PR DESCRIPTION
package "io" is not used when you not use http annotations in .proto file