### PR TITLE
issue:#337, Fixed GOPATH in workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Deps
         env:
-          GOPATH: /home/runner/work/truss/truss/go
+          GOPATH: $GOPATH
           PROTOC_VER: ${{ matrix.protoc }}
         run: |
           sudo apt update && sudo apt install -y git unzip build-essential
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build
         env:
-          GOPATH: /home/runner/work/truss/truss/go
+          GOPATH: $GOPATH
         run: |
           cd go/src/github.com/metaverse/truss
           export PATH=$HOME/bin/:$GOPATH/bin/:$PATH
@@ -51,7 +51,7 @@ jobs:
 
       - name: Test
         env:
-          GOPATH: /home/runner/work/truss/truss/go
+          GOPATH: $GOPATH
         run: |
           export PATH=$HOME/bin/:$GOPATH/bin/:$PATH
           cd go/src/github.com/metaverse/truss

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Deps
         env:
-          GOPATH: $GOPATH
+          GOPATH: $HOME/go
           PROTOC_VER: ${{ matrix.protoc }}
         run: |
           sudo apt update && sudo apt install -y git unzip build-essential
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build
         env:
-          GOPATH: $GOPATH
+          GOPATH: $HOME/go
         run: |
           cd go/src/github.com/metaverse/truss
           export PATH=$HOME/bin/:$GOPATH/bin/:$PATH
@@ -51,7 +51,7 @@ jobs:
 
       - name: Test
         env:
-          GOPATH: $GOPATH
+          GOPATH: $HOME/go
         run: |
           export PATH=$HOME/bin/:$GOPATH/bin/:$PATH
           cd go/src/github.com/metaverse/truss


### PR DESCRIPTION
I was observing exact same issue as #337. Found out that git workflow is using the hardcoded GOPATH due to which transport service tests are broken. Below is the error:

> FATA[0003] cannot generate service: cannot generate gokit service: cannot render template: cannot render template: svc/transport_http.gotemplate: template error: template: svc/transport_http.gotemplate:2:2: executing "svc/transport_http.gotemplate" at <call .HTTPHelper.ServerTemplate .>: error calling call: ERROR: go parser couldn't parse file '/home/runner/work/truss/truss/gengokit/httptransport/embeddable_funcs.go'

Update GOPATH to the env $GOPATH which fixed the issue.