### PR TITLE
fixes warning 'installing executables with 'go get' in module mode is…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ VERSION_DATE := $(shell $(MAKEFILE_PATH)/commit_date.sh)
 default: truss
 
 dependencies:
-	go get -u github.com/gogo/protobuf/protoc-gen-gogo@21df5aa0e680850681b8643f0024f92d3b09930c
-	go get -u github.com/gogo/protobuf/protoc-gen-gogofaster@21df5aa0e680850681b8643f0024f92d3b09930c
-	go get -u github.com/gogo/protobuf/proto@21df5aa0e680850681b8643f0024f92d3b09930c
-	go get -u github.com/kevinburke/go-bindata/go-bindata
+	go get -u -d github.com/gogo/protobuf/protoc-gen-gogo@21df5aa0e680850681b8643f0024f92d3b09930c
+	go get -u -d github.com/gogo/protobuf/protoc-gen-gogofaster@21df5aa0e680850681b8643f0024f92d3b09930c
+	go get -u -d github.com/gogo/protobuf/proto@21df5aa0e680850681b8643f0024f92d3b09930c
+	go get -u -d github.com/kevinburke/go-bindata/go-bindata
 
 # Generate go files containing the all template files in []byte form
 gobindata:


### PR DESCRIPTION
… deprecated.'